### PR TITLE
Rt issue30

### DIFF
--- a/Shim_Greg/ShimOpt_Greg.m
+++ b/Shim_Greg/ShimOpt_Greg.m
@@ -46,13 +46,12 @@ elseif ~isempty( Params.pathToShimReferenceMaps )
 
 end
 
-Shim.Tracker = ProbeTracking( Params.TrackerSpecs )  ; 
-
 %-------
 % associate host MRI 
 if strcmp( Params.InstitutionName, 'IUGM' ) && strcmp( Params.StationName, 'MRC35049' ) 
     Shim.Aux = ShimOpt_IUGM_Prisma_fit(  ) ; % Params input??
 end
+
 if ~isempty( Field )
     Shim.setoriginalfield( Field ) ;
 end
@@ -114,7 +113,6 @@ function  [ Params ] = assigndefaultparameters( Params )
 
 DEFAULT_ISCALIBRATINGREFERENCEMAPS = false ;
 DEFAULT_PATHTOSHIMREFERENCEMAPS    = [ shimbindir() 'ShimReferenceMaps_Greg' ] ;
-DEFAULT_PROBESPECS                 = [] ;
 
 DEFAULT_INSTITUTIONNAME = 'IUGM' ;
 DEFAULT_STATIONNAME     = 'MRC35049' ;
@@ -132,10 +130,6 @@ if ~myisfield( Params, 'pathToShimReferenceMaps' ) || isempty(Params.pathToShimR
     else
         Params.pathToShimReferenceMaps = DEFAULT_PATHTOSHIMREFERENCEMAPS ;
     end
-end
-
-if ~myisfield( Params, 'TrackerSpecs' ) || isempty(Params.TrackerSpecs)
-   Params.TrackerSpecs = DEFAULT_PROBESPECS ;
 end
 
 if ~myisfield( Params, 'InstitutionName' ) || isempty(Params.InstitutionName)

--- a/Shim_IUGM_Prisma_fit/ShimOpt_IUGM_Prisma_fit.m
+++ b/Shim_IUGM_Prisma_fit/ShimOpt_IUGM_Prisma_fit.m
@@ -41,9 +41,6 @@ elseif ~isempty(Params.pathToShimReferenceMaps)
 
 end
 
-Params.TrackerSpecs.state = 'inert' ;
-Shim.Tracker = ProbeTracking( Params.TrackerSpecs )  ; 
-
 if ~isempty( Field ) 
     Shim.setoriginalfield( Field ) ;
 end
@@ -195,7 +192,6 @@ function  [ Params ] = assigndefaultparameters( Params )
 
 DEFAULT_ISCALIBRATINGREFERENCEMAPS = false ;
 DEFAULT_PATHTOSHIMREFERENCEMAPS    = [ shimbindir() 'ShimReferenceMaps_IUGM_Prisma_fit' ] ;
-DEFAULT_PROBESPECS                 = [] ;
 
 if ~myisfield( Params, 'isCalibratingReferenceMaps' ) || isempty(Params.isCalibratingReferenceMaps)
    Params.isCalibratingReferenceMaps = DEFAULT_ISCALIBRATINGREFERENCEMAPS ;
@@ -211,10 +207,6 @@ if ~myisfield( Params, 'pathToShimReferenceMaps' ) || isempty(Params.pathToShimR
         Params.pathToShimReferenceMaps = DEFAULT_PATHTOSHIMREFERENCEMAPS ;
     end
 
-end
-
-if ~myisfield( Params, 'TrackerSpecs' ) || isempty(Params.TrackerSpecs)
-   Params.TrackerSpecs = DEFAULT_PROBESPECS ;
 end
 
 end

--- a/Shim_Rriyan/ShimOpt_Rriyan.m
+++ b/Shim_Rriyan/ShimOpt_Rriyan.m
@@ -16,7 +16,6 @@ classdef ShimOpt_Rriyan < ShimOpt
 % properties % defined in parent class ShimOpt 
     % Field ; % object of type MaRdI
     % Model ;
-    % Tracker ; % object of type ProbeTracking
 % end
 
 % =========================================================================
@@ -52,7 +51,6 @@ elseif ~isempty( Params.pathToShimReferenceMaps )
 
 end
 
-Shim.Tracker = ProbeTracking( Params.TrackerSpecs )  ; 
 
 %-------
 % associate host MRI 
@@ -171,7 +169,6 @@ function  [ Params ] = assigndefaultparameters( Params )
 
 DEFAULT_ISCALIBRATINGREFERENCEMAPS = false ;
 DEFAULT_PATHTOSHIMREFERENCEMAPS    = [ shimbindir() 'ShimReferenceMaps_Rriyan' ] ;
-DEFAULT_PROBESPECS                 = [] ;
 
 DEFAULT_INSTITUTIONNAME = 'IUGM' ;
 DEFAULT_STATIONNAME     = 'MRC35049' ;
@@ -189,10 +186,6 @@ if ~myisfield( Params, 'pathToShimReferenceMaps' ) || isempty(Params.pathToShimR
     else
         Params.pathToShimReferenceMaps = DEFAULT_PATHTOSHIMREFERENCEMAPS ;
     end
-end
-
-if ~myisfield( Params, 'TrackerSpecs' ) || isempty(Params.TrackerSpecs)
-   Params.TrackerSpecs = DEFAULT_PROBESPECS ;
 end
 
 if ~myisfield( Params, 'InstitutionName' ) || isempty(Params.InstitutionName)


### PR DESCRIPTION
transposed the .Aux property (a ProbeTracking object) from ShimOpt to the ShimUse class:
The domain of ShimOpt is now purely 'virtual', no longer interfacing with any hardware. This should simplify use and development of the ShimOpt class.