### PR TITLE
Delegate image file load to "img.Maker" class

### DIFF
--- a/Img/+img/@Grid/Grid.m
+++ b/Img/+img/@Grid/Grid.m
@@ -1,0 +1,306 @@
+classdef Grid 
+%img.Grid Image grid properties
+%
+
+%% ========================================================================
+% Properties
+% =========================================================================    
+
+% NB: Properties that can be calculated on-the-fly from other properties are 
+% 'Dependent' (effectively, return values from inline functions).
+%
+% Properties unlikely to be of direct use to the user are kept Hidden.
+%
+% Properties format:
+%   % Decription (appears in doc display)
+%   name(size) type {validationFunctions} = [default] ;
+
+properties( Constant = true ) % constant until there is reason to change
+
+    % Units of fov, grid positions, grid spacing
+    units char = ['mm'] ; 
+
+end
+
+properties 
+
+    % Grid coordinate system as string. Default = 'PCS' (patient coordinate system)
+    coordinateSystem char = ['PCS'] ;
+
+end
+
+properties( Dependent, SetAccess=private )
+
+    % Field of view dimensions: [Row, Column, Slice]
+    fov(1,3) double {mustBeNonnegative} ; 
+    
+    % Number of grid points (i.e. number of image pixels or voxels)
+    nPoints(1,1) {mustBeInteger} ; 
+
+    % [Column, Row, Slice] orientations as 3x3 mtx of direction cosine column vectors 
+    % 
+    %> The direction cosines of a vector are the cosines of the angles between
+    %> the vector and the three coordinate axes. Equivalently, they are the
+    %> contributions of each component of the basis to a unit vector in that
+    %> direction.
+    % 
+    % https://en.wikipedia.org/wiki/Direction_cosine/
+    rotation(3,3) double {mustBeReal} = [eye(3,3)] ;
+    
+    % 4D array of grid positions: 
+    % xCoordinates=xyz(:,:,:,1) 3-column mtx: rows=[x y z]-patient coordinates of the vectorized grid positions. 
+    %
+    % See also img.Grid.gridpositions
+    xyz(:,:,:,3) double {mustBeReal} ; 
+    
+end
+
+properties( SetAccess=private )
+
+    % Image array dimensions: [#Rows, #Columns, #Slices]
+    size(1,3) {mustBeInteger, mustBePositive} = [1 1 1] ; 
+    
+    % Grid-spacing vector: [Between-Rows, "-Columns, "-Slices]
+    spacing(1,3) double {mustBeNonnegative} = [1 1 1] ;
+    
+end
+
+properties( Dependent, SetAccess=private, Hidden=true )
+
+    % Slice [X;Y,Z] positions. 
+    %
+    % DICOM Hdr Tag: (0020,1041)
+    sliceLocation(3,:) double {mustBeReal} ; 
+    
+    % 3rd column vector of `rotation` matrix 
+    %
+    % Unit vector indicating slice direction (ascending vs. descending)
+    sliceNormalVector(3,1) ; 
+
+end
+
+properties( SetAccess=private, Hidden=true )
+
+    % Column and Row direction cosines. 
+    %
+    % DICOM Hdr Tag: (0020,0037)
+    imageOrientationPatient(6,1) double {mustBeReal} ; 
+
+    % [X Y Z] coordinates of 1st voxel,img(1,1,1). 
+    %
+    % DICOM Hdr Tag: (0020,0032)
+    imagePositionPatient(3,:) {mustBeReal} ; 
+
+end
+
+%% ========================================================================
+% Methods 
+% =========================================================================    
+
+% =========================================================================
+% =========================================================================    
+methods
+% =========================================================================    
+function Self = Grid( Hdrs )
+    
+    if nargin == 0
+        return ;  
+    elseif ( nargin == 1 ) && isstruct( Hdrs )
+        Self = Self.initializefromdicom( Hdrs ) ;
+    else
+        error('Invalid input') ;
+    end
+
+end
+% =========================================================================
+function fov = get.fov( Self )
+%GETFOV  Return field of view dimensions [units: mm]: [Row, Column, Slice]  
+
+    fov = Self.spacing .* double( Self.size ) ;
+
+end
+% =========================================================================
+function nPoints = get.nPoints( Self )
+%GET.NVOXELS  Return # image voxels of a single image volume as scalar double 
+    
+    nPoints = prod( Self.size ) ;
+
+end
+% =========================================================================
+function [R] = get.rotation( Self ) 
+%GET.ROTATION
+% 
+% R = GET.ROTATION( Self ) 
+%   
+% i.e.  `R = [r c s];` where
+% r: row *index* direction cosine
+% c: column index " "
+% s: slice cosine vector: ==  cross( c, r ) OR -cross( c, r ) (i.e. cross( r, c ))
+% depending on whether slices are in acending or descending order,
+%
+% Note the term *index*: r is not the row direction cosine (c is), rather, it
+% is the direction cosine of the vector that points along the direction of
+% increasing row indices (i.e. it is in the column direction!)
+%
+% __ETC__
+% See also [Wikipedia](https://en.wikipedia.org/wiki/Direction_cosine):
+%
+%> The direction cosines of a vector are the cosines of the angles between
+%> the vector and the three coordinate axes. Equivalently, they are the
+%> contributions of each component of the basis to a unit vector in that
+%> direction.
+ 
+    c = Self.imageOrientationPatient(1:3) ; 
+    r = Self.imageOrientationPatient(4:6) ; 
+    s = Self.sliceNormalVector ;
+
+    R = [r c s] ;
+
+end 
+% =========================================================================
+function [sliceLocation] = get.sliceLocation( Self )
+%GET.SLICELOCATION Slice [X;Y;Z] positions as defined by the SliceLocation field of the DICOM hdr 
+
+    for iSlice = 1 : Self.size(3)
+        sliceLocation(:,iSlice) = dot( Self.imagePositionPatient(:,iSlice), Self.sliceNormalVector ) ;
+    end 
+
+end
+% =========================================================================
+function [s] = get.sliceNormalVector( Self )
+%GETSLICENORMALVECTOR Unit vector indicating slice direction (ascending vs. descending)
+%
+% sliceNormalVector = 3rd column vector of rotation
+%
+% Defining:
+%   c = Self.imageOrientationPatient(1:3) 
+%   r = Self.imageOrientationPatient(4:6)
+%   then, s ==  cross( c, r ) OR -cross( c, r ) (i.e. cross( r, c ))
+% 
+% For multiple slices, the calculation in get.sliceNormalVector() determines
+% the correct sign, and defaults arbitrarily to cross( r, c ) in the single
+% slice case.
+%
+% For more info see discussion at 
+% http://nipy.org/nibabel/dicom/dicom_mosaic.html 
+    
+    if Self.size(3) == 0 % arbitrary orientation
+        s = cross( Self.imageOrientationPatient(4:6), Self.imageOrientationPatient(1:3) ) ;
+    else
+        ds = Self.imagePositionPatient(:,end) - Self.imagePositionPatient(:,1) ;
+        s  = ds/( Self.spacing(3) * ( double(Self.size(3)) - 1 ) ) ;
+    end
+
+end
+% =========================================================================
+function [xyz] = get.xyz( Self )
+%GET.XYZ Return grid coordinates as 3-column matrix [ x(:) y(:) z(:) ] 
+
+    [x,y,z] = Self.gridpositions() ;
+    
+    xyz          = zeros( [size(x) 3] ) ;
+    xyz(:,:,:,1) = x ;
+    xyz(:,:,:,2) = y ;
+    xyz(:,:,:,3) = z ;
+
+end
+% =========================================================================
+function [xyz] = set.xyz( Self, xyz4d )
+%SET.XYZ
+
+    if nargin == 1 
+        return ;
+    end
+
+    [X,Y,Z] = deal( xyz4d(:,:,:,1), xyz4d(:,:,:,2), xyz4d(:,:,:,3) ) ;
+
+    %% -----
+    sizeNew = size(X) ;
+
+    %% ------
+    % update spacing
+
+    % Displacements [x; y; z;] between rows, columns, and slices, respectively: dR, dC, dS 
+    dR = [ X(2,1,1) - X(1,1,1) ; Y(2,1,1) - Y(1,1,1) ; Z(2,1,1) - Z(1,1,1) ] ;
+    dC = [ X(1,2,1) - X(1,1,1) ; Y(1,2,1) - Y(1,1,1) ; Z(1,2,1) - Z(1,1,1) ] ;
+        
+    if sizeNew(3) > 1
+        dS = [ X(1,1,2) - X(1,1,1) ; Y(1,1,1) - Y(1,1,2) ; Z(1,1,2) - Z(1,1,1) ] ;
+    else
+        dS = 0 ;
+    end
+
+    spacingNew = sqrt( [ sum(dR.^2) sum(dC.^2) sum(dS.^2) ]  ) ; 
+
+    %% -----
+    % Direction cosines:
+
+    % column (expressing angle between column direction and X,Y,Z axes)
+    imageOrientationPatientNew(4:6) = dR/spacingNew(1) ;
+        
+    % row (expressing angle btw row direction and X,Y,Z axes)
+    imageOrientationPatientNew(1:3) = dC/spacingNew(2) ;
+
+    %% -----
+    % update imagePositionPatient:
+    imagePositionPatientNew = [ X(1,1,:) ; Y(1,1,:) ; Z(1,1,:) ] ;
+
+end
+% =========================================================================
+
+end
+
+% =========================================================================
+% =========================================================================    
+methods( Hidden = true )
+% Hidden for simplicity (overloaded operators should be self-explanatory)
+% =========================================================================
+function isEqual = eq( Self, Grid2 )
+%EQ  Return `true` if positions of two Grid objects coincide 
+
+    if ( ( nargin ~= 2 ) || ~isa( Grid2, 'img.Grid' ) )
+        error('Function requires 2 img.Grid objects as arguments.') ; 
+    elseif ~strcmp( Self.coordinateSystem, Grid2.coordinateSystem ) 
+        error( 'Input grid coordinate systems must match.' ) ;
+    elseif ~strcmp( Self.units, Grid2.units ) 
+        error( 'Input grid units must match.' ) ;
+    else 
+        isEqual =img.Grid.comparegridpositions( Self.xyz, Grid2.xyz ) ;    
+    end
+
+end
+% =========================================================================
+function isNotEqual = neq( Grid1, Grid2 ) 
+%NEQ  Return `false` if positions of two Grid objects coincide 
+
+    isNotEqual = ~eq( Grid1, Grid2 ) ;
+
+end
+% =========================================================================    
+
+end
+% =========================================================================
+% Larger methods in separate files
+% =========================================================================
+methods
+    %.....
+    [x,y,z] = gridpositions( Self )
+end
+
+methods( Static )
+    %.....
+    isSame = comparegrids( varargin )
+end
+
+methods( Access=private )
+    %.....
+    [Self] = initializefromdicom( Self, Hdrs )
+    %.....
+    []     = update( Self, X, Y, Z )
+end
+% =========================================================================
+%
+% =========================================================================
+
+
+end

--- a/Img/+img/@Grid/comparegrids.m
+++ b/Img/+img/@Grid/comparegrids.m
@@ -1,0 +1,32 @@
+function isSame = comparegrids( varargin )
+%COMPAREGRIDS Return `true` if voxel positions coincide 
+%        
+%     isSame = comparegrids( Grid1, Grid2 )
+%     isSame = comparegrids( xyz1, xyz2 )
+%     isSame = comparegrids( X1, Y1, Z1, X2, Y2, Z2 )
+% 
+% Wrapper function to `img.Grid.isequal()`
+%
+% __ETC__
+%
+% See also 
+% img.Grid.isequal
+
+    if nargin == 2
+        if isa( varargin{1}, 'img.Grid' ) && isa( varargin{2}, 'img.Grid' )
+            isSame = ( varargin{1} == varargin{2} ) ;   
+        elseif isnumeric( varargin{1} ) && isnumeric( varargin{2} )
+            isSame = isequal( varargin{1}, varargin{2} ) ; 
+        end
+    elseif ( nargin ==6 ) && all( cellfun( @isnumeric, varargin ) )
+        isSame  = isequal( varargin{1}, varargin{4} ) ... % compare X-coordinates
+               && isequal( varargin{2}, varargin{5} ) ... % compare Y-coordinates 
+               && isequal( varargin{3}, varargin{6} ) ;   % compare Z-coordinates 
+    end
+
+    if ~exist( 'isSame' )
+        error( 'See HELP Grid.comparegrids' ) ;
+    end
+
+end
+

--- a/Img/+img/@Grid/gridpositions.m
+++ b/Img/+img/@Grid/gridpositions.m
@@ -1,0 +1,25 @@
+function [x,y,z] = gridpositions( Self )
+%GRIDPOSITIONS  Return [x,y,z]: Three 2- or 3-D arrays of voxel positions 
+% 
+% [x,y,z] = Self.gridpositions( ) 
+%
+% Returns three 3D arrays of doubles, each element containing the
+% location [units: mm] of the corresponding voxel with respect to 
+% DICOM's 'Reference Coordinate System'.
+
+    % Arrays of voxel row, column, and slice indices
+    [iRows,iColumns,iSlices] = ndgrid( [0:1:Self.size(1)-1], ...
+                      [0:1:Self.size(2)-1], ...
+                      [0:1:Self.size(3)-1] ) ; 
+
+    % Rotation and Scaling matrix: RS  
+    RS = Self.rotation * diag(Self.spacing) ;
+
+    % Scale and rotate to align row direction with x-axis, column direction
+    % with y-axis, slice with z-axis; then translate w.r.t origin (via ImagePositionPatient)
+    x = ( RS(1,1)*iRows + RS(1,2)*iColumns + RS(1,3)*iSlices ) + Self.imagePositionPatient(1) ;
+    y = ( RS(2,1)*iRows + RS(2,2)*iColumns + RS(2,3)*iSlices ) + Self.imagePositionPatient(2) ;
+    z = ( RS(3,1)*iRows + RS(3,2)*iColumns + RS(3,3)*iSlices ) + Self.imagePositionPatient(3) ;
+
+end
+

--- a/Img/+img/@Grid/initializefromdicom.m
+++ b/Img/+img/@Grid/initializefromdicom.m
@@ -1,0 +1,53 @@
+function [Self] = initializefromdicom( Self, Hdrs ) 
+%INITIALIZEFROMDICOM
+
+% "If Anatomical Orientation Type (0010,2210) is absent or has a value of
+% BIPED, the x-axis is increasing to the left hand side of the patient. The
+% y-axis is increasing to the posterior side of the patient. The z-axis is
+% increasing toward the head of the patient."
+%
+% from DICOM standard: https://www.dabsoft.ch/dicom/3/C.7.6.2.1.1/
+% assert( ~myisfield( Self.Img.Hdr, 'AnatomicalOrientationType' ) || ...
+%             strcmp( Self.Img.Hdr.AnatomicalOrientationType, 'BIPED' ), ...
+%             'Error: AnatomicalOrientationType not supported.' ) ;
+
+Self.size = double( [Hdrs(1).Rows Hdrs(2).Columns size(Hdrs, 1) ] ) ;
+
+Self.imageOrientationPatient = Hdrs(1).ImageOrientationPatient ;
+
+if isfield( Hdrs, 'SpacingBetweenSlices' )
+    Self.spacing = [ Hdrs(1).PixelSpacing(1) Hdrs(1).PixelSpacing(2) Hdrs(1).SpacingBetweenSlices ] ;
+else
+    Self.spacing = [ Hdrs(1).PixelSpacing(1) Hdrs(1).PixelSpacing(2) Hdrs(1).SliceThickness ] ;
+end
+
+for iSlice = 1 : Self.size(3)
+    Self.imagePositionPatient(:, iSlice) = Hdrs(iSlice, 1).ImagePositionPatient ;
+end
+
+
+% if size( Self.Img.img, 3 ) > 1
+% % Determine: ascending or descending slices?
+%
+%     % Estimate positions of last slice using the position of the 1st image 
+%     % and the 2 possibilities for the SliceNormalVector:
+%
+%     % 1. using cross( c, r ) ;
+%     % [X1,Y1,Z1] = [Self.voxelPositions.X, Self.voxelPositions.Y, Self.voxelPositions.Z] ;     
+%     [X1,Y1,Z1] = deal( Self.voxelPositions.X,  Self.voxelPositions.Y, Self.voxelPositions.Z ) ;
+%     
+%     % 2. using the reverse
+%     Self.SliceNormalVector = cross( r, c ) ;
+%     [X2,Y2,Z2] = deal( Self.voxelPositions.X,  Self.voxelPositions.Y, Self.voxelPositions.Z ) ;
+%     
+%     % Actual position corresponding to the slice direction can be increasing or
+%     % decreasing with slice/image number. So, which estimate is closer: 1 or 2? 
+%     if norm( Self.Img.Hdrs{end,1,1}.ImagePositionPatient' - [ X1(1,1,end) Y1(1,1,end) Z1(1,1,end) ] ) < ...
+%             norm( Self.Img.Hdrs{end,1,1}.ImagePositionPatient' - [ X2(1,1,end) Y2(1,1,end) Z2(1,1,end) ] ) 
+%         % if true, then 1. corresponds to the correct orientation
+%         Self.SliceNormalVector = cross( c, r ) ;
+%     end
+% end
+%     
+
+end

--- a/Img/+img/@Grid/update.m
+++ b/Img/+img/@Grid/update.m
@@ -1,0 +1,42 @@
+function [] = update( Self, X, Y, Z )
+%UPDATE Update image grid positions
+%     
+%     update( Self, X, Y, Z ) 
+
+if ( nargin ~= 4 ) || ~isequal( size(X), size(Y), size(Z) ) 
+    error( ['Function requires 4 arguments: img.Grid object followed by ' ...
+            '3 identically-sized position arrays X, Y, Z with regular spacing'] ) ;
+end
+
+sizeNew = size(X) ;
+
+% ---------------
+%% Update spacing
+
+% Displacements [x; y; z;] between rows, columns, and slices, respectively: dR, dC, dS 
+dR = [ X(2,1,1) - X(1,1,1) ; Y(2,1,1) - Y(1,1,1) ; Z(2,1,1) - Z(1,1,1) ] ;
+dC = [ X(1,2,1) - X(1,1,1) ; Y(1,2,1) - Y(1,1,1) ; Z(1,2,1) - Z(1,1,1) ] ;
+    
+if sizeNew(3) > 1
+    dS = [ X(1,1,2) - X(1,1,1) ; Y(1,1,1) - Y(1,1,2) ; Z(1,1,2) - Z(1,1,1) ] ;
+else
+    dS = 0 ;
+end
+
+spacingNew = sqrt( [ sum(dR.^2) sum(dC.^2) sum(dS.^2) ]  ) ; 
+
+% -------------------
+%% Direction cosines:
+
+% column (expressing angle between column direction and X,Y,Z axes)
+imageOrientationPatientNew(4:6) = dR/spacingNew(1) ;
+    
+% row (expressing angle btw row direction and X,Y,Z axes)
+imageOrientationPatientNew(1:3) = dC/spacingNew(2) ;
+
+% ----------------------------
+%% Update imagePositionPatient:
+imagePositionPatientNew = [ X(1,1,:) ; Y(1,1,:) ; Z(1,1,:) ] ;
+
+end
+

--- a/Img/+img/@Maker/Maker.m
+++ b/Img/+img/@Maker/Maker.m
@@ -1,0 +1,71 @@
+classdef (Sealed, Hidden) Maker < handle
+%img.Maker Loads and sorts image files for the construction of Img objects 
+%
+% img.Maker facilitates the construction of image objects by
+% finding, organizing, and loading image files.
+%
+% Further, (TODO) it will handle typecasting of generic images into specific subtypes when appropriate
+% (e.g. if files are phase images, `img.Maker` should convert them).
+% 
+% __DEV NOTE__
+% This class should only ever need to be accessed via the `img.make()`
+% function: the public interface to create image objects). 
+%
+% As such, class methods could technically all be local functions within
+% `img.make`; however, doing so would *make* that single file extremely
+% complicated. Delegating and compartmentalizing the various tasks involved
+% with loading image files to the methods of this class seems likely to be more
+% maintainable. 
+%
+% Also, it constitutes a step toward keeping the interface and
+% implementation [separate.](https://oop.tech-academy.co.uk/interface-vs-implementation/)
+
+    
+% % Byte limit on image loading (loading aborts when exceeded) [default: 2E9]
+% %
+% % NOTE: Matlab memory() function exists to query available memory but
+% % it currently only works for Windows...
+% nBytesMax(1,1) {mustBePositive} = 2*( 1E9 ) ;
+%
+% % Determines whether MrdiIo.make typecasts Mrdi objects to known subclasses [default: TRUE]
+% isConverting(1,1) {mustBeNumericOrLogical} = true ;
+
+properties( Constant = true ) 
+
+    % Struct of image file extensions 
+    % dicom: known dicom file extensions
+    % nifti: known nifti file extensions
+    FileExt = struct( 'dicom', [ ".dcm" ".IMA" ], ...
+                      'nifti', ".nii" ) ;
+
+    % File types (extensions) supported for Img object instantiation (restricted now to dicoms)
+    supportedInputs = [".dcm" ".IMA"] ;
+
+end
+
+% =========================================================================
+% =========================================================================    
+methods
+% =========================================================================    
+function Io = Maker( )
+    return;
+end
+% =========================================================================
+
+end
+% =========================================================================
+% =========================================================================    
+methods(Static) 
+    %.....
+    [Hdr]        = dicominfosiemens( varargin )
+    %.....
+    [List]       = findimagefiles( searchDir, fileExt, isSearchRecursive )
+    %.....
+    [data, Hdrs] = loadandsortdicoms( List ) 
+    %.....
+    [data, Hdrs] = loadandsortimages( List, nBytesMax )
+end
+% =========================================================================
+% =========================================================================
+
+end

--- a/Img/+img/@Maker/findimagefiles.m
+++ b/Img/+img/@Maker/findimagefiles.m
@@ -1,0 +1,63 @@
+function [List] = findimagefiles( sFolder, fileExt, isRecursive )
+%FINDIMAGEFILES Returns list of image files from `dir()` search
+%      
+%      List = findimagefiles( sFolder, fileExt, isRecursive )
+% 
+% Looks for image files in `sFolder` with extensions `fileExt` and returns
+% the file matches as elements of a 1-D struct array `List`.
+%
+% __INPUTS__
+%   
+%   sFolder=["."]  
+%     Base directory of the search as a string scalar or char vector. 
+%
+%   fileExt=[img.Maker.supportedInputs]  
+%     File extension(s) of interest as a string vector (e.g. `[".dcm", ".IMA" ]`)
+%
+%   isRecursive=[false|0]  
+%     Toggle to include (1) or exclude (0) subdirectories.
+%
+% __ETC__ 
+%
+% `findimagefiles` wraps to MATLAB function `dir()`
+%
+% See also 
+% DIR — https://www.mathworks.com/help/matlab/ref/dir.html
+% img.Maker.loadandsortimages
+    arguments
+        sFolder(1,:) {mustBeFileOrFolder} = "." ;
+        fileExt string  = img.Maker.supportedInputs ;
+        isRecursive(1,1) {mustBeBoolean} = false ;
+    end
+
+%% Cast as string
+searchStr = string( fullfile( sFolder, filesep ) ) ;
+
+if isRecursive
+    searchStr = fullfile( searchStr, "**", filesep )  ;
+end
+
+searchStr = searchStr + "*" ;
+
+%% Search
+List = dir( strcat( searchStr, fileExt(1) ) ) ;
+
+for iPattern = 2 : numel( fileExt )
+    List = [ List ; dir( strcat( searchStr, fileExt(iPattern) ) ) ] ;
+end
+
+[paths, iUnique] = unique( fullfile( string({List(:).folder})', string({List(:).name})' ) ) ;
+List             = List(iUnique) ; 
+
+%% Exclude directories and hidden files
+if isunix
+    List = List( ~[ List(:).isdir ]' & ~contains( paths, filesep + "." ) ) ;
+else 
+    [~, Attributes] = arrayfun( @fileattrib, paths ) ;
+    List = List( ~[ Attributes.directory(:) ] & ~[ Attributes.hidden(:) ] ) ;
+end
+
+display( [ num2str(length(List)) ' images found [totaling ' ...
+           num2str( sum([ List(:).bytes ]) ) ' bytes].' ] ) ; 
+
+end

--- a/Img/+img/@Maker/loadandsortdicoms.m
+++ b/Img/+img/@Maker/loadandsortdicoms.m
@@ -1,0 +1,313 @@
+function [imgs, Hdrs] = loadandsortdicoms( List ) 
+%LOADANDSORTDICOMS  Load and sort dicoms from file list
+%     
+%     [imgs, Hdrs] = loadandsortdicoms( List )
+%
+% Accepts a `List` of dicom file names to load, and sorts the images and headers
+% into 2 cell arrays which respectively contain numeric arrays of images, and
+% struct arrays of headers. Each acquisition series is assigned to a separate
+% element of the returned cells.
+%
+% `List` is a 1-D struct array of file paths returned from `img.findimagefiles`.
+%
+% Sorting of the returned arrays occurs according to slice, echo time,
+% measurement number, and channel. 
+%
+% For the image arrays, these dimensions are respectively 3, 4, 5, and 6;
+%
+% For the headers, they are respectively 1,2,3, and 4.
+    arguments
+        List(:,1) struct ;
+    end
+
+imgs = [] ;
+Hdrs = [] ;
+
+%% Load and sort headers
+Hdrs    = loaddicomheaders( List ) ;
+nSeries = numel( Hdrs ) ; 
+
+Progress = CmdLineProgressBar( [ num2str(nSeries) ' acquisition series found. Sorting headers:' ]);
+
+for iSeries = 1 : nSeries 
+    Progress.print( iSeries, nSeries ) ;
+    Hdrs{iSeries} = sortdicomheaders( Hdrs{iSeries} ) ;   
+end
+
+%% Augment data struct with Siemens private header courtesy of parse_siemens_shadow()
+if strcmp( Hdrs{1}(1).Manufacturer, 'SIEMENS' )
+    Progress = CmdLineProgressBar( [ 'Parsing Siemens private header for 1st image in series: ' ] );
+
+    for iSeries = 1 : nSeries 
+        Progress.print( iSeries, nSeries ) ;
+        % NOTE: Ideally, dicominfosiemens() would be used for every DICOM file,
+        % however, it is rather slow. Compromise: parse the private metadata
+        % for the first image in the series only, as much of it will be
+        % constant across the series (i.e. across DICOM files).
+        ExtendedHdr             = dicominfosiemens( Hdrs{iSeries}(1) ) ;
+        Hdrs{iSeries}(1).Img    = ExtendedHdr.Img ; 
+        Hdrs{iSeries}(1).Ser    = ExtendedHdr.Ser ; 
+        Hdrs{iSeries}(1).MrProt = ExtendedHdr.MrProt ; 
+    end
+end
+
+imgs = loaddicomimages( Hdrs ) ;
+
+end
+
+% -----
+%% Internal functions
+
+function [ Hdrs ] = loaddicomheaders( List )
+%LOADDICOMHEADERS  Return cell array of DICOM Hdr structs
+%     
+%     Hdrs = loaddicomheaders( List )
+% 
+% `loaddicomheaders` wraps to `dicominfo` for each element in `List` (a struct
+% (e.g. returned from `dir()`) whereby fields .name and .folder describe the
+% DICOM files to be loaded. 
+%
+% Headers from DICOMs belonging to the same series (indicated by the field
+% .SeriesInstanceUID) are grouped into the same struct array, which becomes an
+% element of the returned cell array Hdrs. 
+% 
+% Returned Hdrs is then a 1-D cell array, with as many elements as there are
+% distinct acquisition series. 
+
+    nImg = length( List ) ;
+    
+    Hdrs               = cell( 1, 1 ) ; % cell containing dicom header struct arrays
+    nSeries            = 0 ; % number of series found
+    seriesInstanceUIDs = "" ; % string array holding SeriesInstanceUID's
+    Progress           = CmdLineProgressBar([ 'Loading image headers: ' ]);
+
+    for iImg = 1 : nImg 
+        
+        Progress.print( iImg, nImg ) ;
+        
+        Hdr     = dicominfo( [List(iImg).folder filesep List(iImg).name] ) ;
+        % Check if new Hdr corresponds to previously loaded series; 
+        % if not, append new entry.
+        iSeries = find( Hdr.SeriesInstanceUID == seriesInstanceUIDs ) ;
+        
+        if isempty( iSeries )
+            nSeries = nSeries + 1 ;
+            iSeries = nSeries ;
+            seriesInstanceUIDs(nSeries) = string( Hdr.SeriesInstanceUID ) ;
+            Hdrs{iSeries} = Hdr ;
+        else
+            Hdrs{iSeries}(end+1) = Hdr ;
+        end
+    end
+
+end % loaddicomheaders
+
+function [ HdrsSorted ] = sortdicomheaders( Hdrs )
+%SORTDICOMHEADERS Reorders and reshapes 1-d DICOM header struct array 
+%     
+%     HdrsSorted = sortdicomheaders( Hdrs )
+% 
+% Input `Hdrs` should be a 1-d struct-array of DICOM Hdrs, in no particular
+% order, where all elements (i.e. every included DICOM header) belong to the
+% same acquisition series. 
+%
+% Output `HdrsSorted` has same number of elements as the input, but is
+% reordered and arrayed such that its dimensions refer, respectively, to 
+% ( Slice, Echo, Acquisition, Channel )
+    arguments
+        Hdrs {mustBeValidHeader} ;
+    end
+
+    nImgInSeries      = length( Hdrs ) ;
+
+    nRows             = unique( [ Hdrs(:).Rows ] ) ;
+    nColumns          = unique( [ Hdrs(:).Columns ] ) ;
+
+    sliceLocations    = unique( [ Hdrs(:).SliceLocation ] ) ;
+    nSlices           = length( sliceLocations ) ;
+
+    echoTimes         = unique( [ Hdrs(:).EchoTime ] ) ;
+    nEchoes           = length( echoTimes ) ;
+
+    acquisitionNumber = unique( [ Hdrs(:).AcquisitionNumber ] ) ;
+    nAcquisitions     = length( acquisitionNumber ) ;
+
+    channels          = unique( string( { Hdrs(:).Private_0051_100f } ) ) ;
+    nChannels         = length( channels ) ;
+
+    % Initialize
+    HdrsSorted = Hdrs(1) ; 
+
+    for iImg = 1 : nImgInSeries 
+        
+       iSlice        = find( Hdrs(iImg).SliceLocation == sliceLocations ) ;
+       iEcho         = find( Hdrs(iImg).EchoTime == echoTimes ) ;
+       iAcquisition  = find( Hdrs(iImg).AcquisitionNumber == acquisitionNumber ) ;
+       iChannel      = find( Hdrs(iImg).Private_0051_100f == channels ) ;
+
+       HdrsSorted(iSlice, iEcho, iAcquisition, iChannel) = Hdrs(iImg) ;
+    
+    end
+
+end % sortdicomheaders
+
+%% -----
+function [ imgs ] = loaddicomimages( Hdrs )
+%LOADDICOMIMAGES  Return cell array of dicom images 
+%     
+%     [ imgs ] = loaddicomimages( Hdrs )
+%
+% `Hdrs` is a cell array, wherein each element is a struct array of dicom headers.
+% Return cell array `imgs` is the same size as `Hdrs`, and each element is an image
+% array, its size a function of the corresponding `Hdrs{i}` entry
+
+    nSeries  = numel( Hdrs ) ;
+    imgs     = cell( 1, nSeries ) ;
+
+    Progress = CmdLineProgressBar( [ 'Loading images: ' ] );
+
+    for iSeries = 1 : nSeries 
+
+        Progress.print( iSeries, nSeries ) ;
+
+        [ nSlices, nEchoes, nMeasurements, nChannels ] = size( Hdrs{iSeries} ) ;
+
+        for iSlice = 1 : nSlices
+            for iEcho = 1 : nEchoes
+                for iMeasurement = 1 : nMeasurements
+                    for iChannel = 1 : nChannels
+                        img(:,:,iSlice,iEcho,iMeasurement,iChannel) = ...
+                            dicomread( Hdrs{iSeries}(iSlice, iEcho, iMeasurement, iChannel) ) ;
+                    end
+                end
+            end
+        end
+    
+        imgs{iSeries} = img ;
+        clear img ;
+
+    end
+
+end % loaddicomimages
+
+function [] = mustBeValidHeader( Hdrs )
+%mustBeValidHeader Issues an error if an image header (struct) is invalid 
+%     
+%     [] = mustBeValidHeader( Hdrs )
+%
+% `Hdrs` can be a DICOM header struct as returned by `dicominfo`. If it does
+% not contain the necessary data fields to permit the construction of a
+% img-object, then an error is thrown.
+    if nargin ~= 1 || ~isstruct( Hdrs )
+        error('Function requires single input argument: Hdrs struct array.' ) ;
+    end
+    
+    %% Check fields exist
+    REQUIRED_FIELDS = { 'SeriesInstanceUID'; 
+                        'Rows'; 
+                        'Columns'; 
+                        'PixelSpacing' ; 
+                        'ImageOrientationPatient' ; 
+                        'ImagePositionPatient' ; 
+                      } ;
+    
+    
+    if any( ~isfield( Hdrs, REQUIRED_FIELDS ) )
+        missingFields = { REQUIRED_FIELDS{ ~isfield( Hdrs, REQUIRED_FIELDS ) } } ;
+        error( [ 'Required Hdr fields not defined:\n .' strjoin( missingFields, '\n .' ) ], '%s' ) ; 
+    end
+    
+    assert( isfield( Hdrs, 'SliceThickness' ) | isfield( Hdrs, 'SpacingBetweenSlices' ), ...
+        'Expected Hdr entry for at least one of the fields .SliceThickness or .SpacingBetweenSlices' ) ;
+
+    %% Check field entries that should possess a unique value
+    assert( length( unique( string( { Hdrs(:).SeriesInstanceUID } ) ) ) == 1, ...
+        'All elements of the DICOM Headers struct array must belong to the same acquisition series' ) ;
+
+    assert( length(unique( [ Hdrs(:).Rows ] )) == 1, ...
+        'Expected unique Hdr entry for .Rows' ) ;
+    
+    assert( length( unique( [ Hdrs(:).Columns ] ) ) == 1, ...
+        'Expected unique Hdr entry for .Columns' ) ;
+
+    % NOTE/TODO
+    % The following conditions need to be met for instantiating an img.Grid
+    % object, however, they may not pass for acquisitions with multiple slice
+    % groups (e.g. localizer)...
+    
+    % pixelSpacing = [ Hdrs(:).PixelSpacing ] ;
+    %
+    % assert( ( length( unique( pixelSpacing(1,:) ) ) == 1 ) || ...
+    %         ( length( unique( pixelSpacing(2,:) ) ) == 1 ), ...
+    %     'Expected unique Hdr entry for both .PixelSpacing(1) and .PixelSpacing(2)' ) ;
+    %
+    % if myisfield( Hdrs, 'SliceThickness' )
+    %     assert( length( unique( [ Hdrs(:).SliceThickness ] ) ) == 1, ...
+    %         'Expected unique Hdr entry for .SliceThickness' ) ;
+    % end
+    %
+    % if myisfield( Hdrs, 'SpacingBetweenSlices' )
+    %     assert( length( unique( [ Hdrs(:).SpacingBetweenSlices ] ) ) == 1, ...
+    %         'Expected unique Hdr entry for .SpacingBetweenSlices' ) ;
+    % end
+
+end % mustBeValidHeader
+
+%% -----
+function [img, Hdr] = reshapemosaic( img, Hdr )
+%RESHAPEMOSAIC Reshape Siemens mosaic into volume array and remove padded zeros
+%
+% Adapted from [dicm2nii](http://www.mathworks.com/matlabcentral/fileexchange/42997/) by xiangrui.li@gmail.com 
+
+error('DEPRECATED')
+assert( ~isempty(strfind( Img.Hdr.ImageType, 'MOSAIC' ) ), 'Corrupt image header?' ) ;       
+
+nImgPerLine = ceil( sqrt( Img.getnumberofslices() ) ); % always nImgPerLine x nImgPerLine tiles
+
+nRows    = size(Img.img, 1) / nImgPerLine; 
+nColumns = size(Img.img, 2) / nImgPerLine; 
+nEchoes  = size(Img.img, 4) ;  
+nVolumes = size(Img.img, 5) ;
+
+img = zeros([nRows nColumns Img.getnumberofslices() nEchoes nVolumes], class(Img.img));
+
+for iImg = 1 : Img.getnumberofslices()
+
+    % 2nd slice is tile(1,2)
+    r = floor((iImg-1)/nImgPerLine) * nRows + (1:nRows);     
+    c = mod(iImg-1, nImgPerLine) * nColumns + (1:nColumns);
+
+    img(:, :, iImg, :) = Img.img(r, c, :);
+end
+
+Img.img = img ;
+
+
+% -----
+% Update header
+
+% -----
+% Correct Hdr.ImagePositionPatient 
+%   see: http://nipy.org/nibabel/dicom/dicom_mosaic.html
+
+%-------
+% Rotation and Scaling matrix: RS  
+RS = Img.rotationMatrix * diag(Img.voxelSpacing) ;
+
+Img.Hdr.ImagePositionPatient = Img.Hdr.ImagePositionPatient + ...
+    RS(:,1)*(double(Img.Hdr.Rows) - nRows)/2 + ...
+    RS(:,2)*(double(Img.Hdr.Columns) - nColumns)/2 ;
+
+
+Img.Hdr.Rows    = uint16(nRows) ;
+Img.Hdr.Columns = uint16(nColumns) ;
+
+tmp = strfind( Img.Hdr.ImageType, '\MOSAIC' ) ;
+
+if ~isempty(tmp) && (tmp > 1)
+    Img.Hdr.ImageType = Img.Hdr.ImageType(1:tmp-1) ;
+else
+    Img.Hdr.ImageType = '' ;    
+end
+
+end %reshapemosaic

--- a/Img/+img/@Maker/loadandsortimages.m
+++ b/Img/+img/@Maker/loadandsortimages.m
@@ -1,0 +1,77 @@
+function [imgs, Hdrs] = loadandsortimages( List )
+%LOADANDSORTIMAGES Load and sort image files
+%
+%     [imgs, Hdrs] = loadandsortimages( List ) 
+%
+% Loads a `List` of image files (returned from `findimagefiles`) and sorts
+% images+headers into 2 cell arrays: 
+%
+% —`imgs` contains numeric arrays of image data (e.g. voxel values); 
+%
+% —`Hdrs` contains struct arrays of headers.
+%
+% When `List` contains images from multiple acquisition series, each
+% series becomes a separate element of the returned cells.
+%
+% Each series array (i.e. cell-element `i`) is sorted according to 
+% slice, echo time, measurement number, channel number:
+%
+% For `imgs{i}`, these dimensions are respectively 3, 4, 5, and 6;
+%
+% For `Hdrs{i}`, they are respectively 1, 2, 3, and 4.
+%
+% __NOTE__
+% Returns are issued as cell arrays presuming it may be useful to create
+% several `Img` objects at once, i.e.: User provides a path to `img.make()`
+% containing several (e.g. scan series) image subdirectories, in which case,
+% successive series are likely to possess different numbers of images (so,
+% arrays `imgs{i+1}` and `Hdrs{i+1}` would be sized differently from their
+% preceding elements). 
+% For now, loading will be restricted to 1 series (directory) at a time.
+% 
+% __ETC__ 
+%
+% See also 
+% img.Maker.findimagefiles, img.make
+    arguments
+        List(:,1) struct ;
+    end
+
+imgs = [] ;
+Hdrs = [] ;
+
+if isempty(List)
+    warning('List of image files was empty.') ; 
+    return ;
+elseif ~isfield( List, 'bytes' ) || ~isfield( List, 'name' )
+    error('Invalid input: List should be a struct returned from img.Maker.findimagefiles()')
+end
+
+%% Extract specific file types (e.g. Dicom) as they will need to be handled differently
+filenames = string( [ { List(:).name } ] ) ;
+
+%% Dicoms: 
+if any( endsWith( filenames, img.Maker.FileExt.dicom ) )
+    [imgs, Hdrs] = img.Maker.loadandsortdicoms( List( endsWith( filenames, img.Maker.FileExt.dicom ) ) ) ;
+end
+
+%% Etc: (if other supported file types are added)
+
+end
+
+% DEV NOTE: 
+% Consider +optional argument limitting the data size loaded to memory.
+% Not adding now for simplicity + it may not be needed.
+% Also note that the Matlab `memory` function can query available memory but
+% it currently only works on Windows.
+%
+% e.g.
+%     [imgs, Hdrs] = loadandsortimages( List, nBytesMax ) 
+%
+% nBytesMax(1,1) {mustBePositive} = 2E9 ;
+%    nBytesMax=[2E9]
+%      Byte limit on load. The function aborts if the limit is exceeded.
+%
+%% Check total file size 
+% assert( sum( [ List(:).bytes ] ) < nBytesMax, [ 'Byte limit exceeded [%s GB].\n ' ...
+%     'Select a new image path or byte limit and run again.' ], num2str( nBytesMax/1E9 ) ) ;

--- a/Img/+img/make.m
+++ b/Img/+img/make.m
@@ -1,0 +1,37 @@
+function [Imgs] = make( searchDir ) 
+%MAKE Constructs an `Img` object from file 
+%     
+%     [Imgs] = make( searchDir ) 
+%
+% Initializes an `Img` image object with the image data found in `searchDir`. 
+%
+% __INPUTS__
+%   
+%   `searchDir` 
+%     directory to search for images (string or char array)
+    arguments
+        searchDir(1,:) string {mustBeFileOrFolder};
+    end
+   
+Maker = img.Maker;
+
+%% Find image files 
+List = Maker.findimagefiles( searchDir );
+
+%% Read in files
+[imgs, Hdrs] = Maker.loadandsortimages( List );
+
+% %% ----- 
+% % Initialize Img objects 
+% for iSeries = 1 : numel( imgs )
+%     Imgs{iImg} = MaRdI( imgs{iSeries}, Hdrs{iSeries} ) ;
+% end
+
+% When the image type is known to correspond to a specific Img
+% child class, the object should be typecast accordingly.
+%
+% isConverting(1,1) {mustBeNumericOrLogical} = true ;
+% Determines whether MrdiIo.make typecasts Mrdi objects to known subclasses [default: TRUE]
+
+
+end

--- a/external/CmdLineProgressBar/CmdLineProgressBar.m
+++ b/external/CmdLineProgressBar/CmdLineProgressBar.m
@@ -1,0 +1,40 @@
+classdef CmdLineProgressBar < handle
+% class for command-line progress-bar notification.
+% Use example:
+%   pb = CmdLineProgressBar('Doing stuff...');
+%   for k = 1 : 10
+%       pb.print(k,10)
+%       % do stuff
+%   end
+%
+% Author: Itamar Katz, itakatz@gmail.com
+% Ita Katz (2020). Command-line progress bar (waitbar)
+% (https://www.mathworks.com/matlabcentral/fileexchange/56871-command-line-progress-bar-waitbar),
+% MATLAB Central File Exchange. Retrieved January 20, 2020. 
+    
+    properties
+        last_msg_len = 0;
+    end
+    methods
+        %--- ctor
+        function obj = CmdLineProgressBar(msg)
+            fprintf('%s', msg)
+        end
+        %--- print method
+        function print(obj, n, tot)
+            fprintf('%s', char(8*ones(1, obj.last_msg_len))) % delete last info_str
+            info_str = sprintf('%d/%d', n, tot);
+            fprintf('%s', info_str);
+            %--- assume user counts monotonically
+            if n == tot
+                delete(obj) ;
+                return ;
+            end
+            obj.last_msg_len = length(info_str);
+        end
+        %--- dtor
+        function delete(obj)
+            fprintf('\n')
+        end
+    end
+end

--- a/external/CmdLineProgressBar/license.txt
+++ b/external/CmdLineProgressBar/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2016, Ita Katz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This PR addresses issue 63 by introducing a new class: [`Maker`](https://github.com/shimming-toolbox/shimming-toolbox/compare/rt/63-imgMaker?expand=1#diff-7ebf86a46e9f0a24a7ef1124f6502d2e) (contained in a [package](https://www.mathworks.com/help/matlab/matlab_oop/scoping-classes-with-packages.html) namespace `img`)

Next step: Refactor `MaRdI` by delegating to `img.Maker`