### PR TITLE
Set up CI and doc build with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,5 +14,12 @@ steps:
     # And worse, our Matlab license only allows one process at a time (TODO: verify this),
     # so a forgotten `quit` will block all tests on all branches.
     # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
-    matlab -nojvm -nodisplay -nosplash -r "disp('Hello from Matlab'); quit"
+    matlab -nodisplay -nosplash -r "disp('Unit tests!'); quit"
   displayName: 'Unit Tests'
+- script: |
+    # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
+    # And worse, our Matlab license only allows one process at a time (TODO: verify this),
+    # so a forgotten `quit` will block all tests on all branches.
+    # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
+    matlab -nodisplay -nosplash -r "disp('Build the docs!'); quit"
+  displayName: 'Build doc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,10 @@
 pool: 'Tristano'
 
 steps:
-- displayName: 'Unit Tests'
-  script: |
+- script: |
     # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
     # And worse, our Matlab license only allows one process at a time (TODO: verify this),
     # so a forgotten `quit` will block all tests on all branches.
     # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
     matlab -nojvm -nodisplay -nosplash -r "disp('Hello from Matlab'); quit"
+  displayName: 'Unit Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,5 +21,5 @@ steps:
     # And worse, our Matlab license only allows one process at a time (TODO: verify this),
     # so a forgotten `quit` will block all tests on all branches.
     # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
-    matlab -nodisplay -nosplash -r "disp('Build the docs!'); quit"
+    matlab -nodisplay -nosplash -r "generate_doc.m; quit"
   displayName: 'Build doc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,18 @@
+# Run shimming-toolbox unit tests.
+
+# TODO:
+#trigger:
+#- master
+
+# use the self-hosted runner at tristano.neuro.polymtl.ca
+# this has Matlab installed and a license to use it.
+pool: 'Tristano'
+
+steps:
+- displayName: 'Unit Tests'
+  script: |
+    # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
+    # And worse, our Matlab license only allows one process at a time (TODO: verify this),
+    # so a forgotten `quit` will block all tests on all branches.
+    # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
+    matlab -nojvm -nodisplay -nosplash -r "disp('Hello from Matlab'); quit"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 
 # use the self-hosted runner at tristano.neuro.polymtl.ca
 # this has Matlab installed and a license to use it.
-pool: 'Tristano'
+pool: 'Default'
 
 steps:
 - script: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+# Hello world!

--- a/generate_doc.m
+++ b/generate_doc.m
@@ -1,0 +1,161 @@
+%% HEADER
+% This function crawls across the various folders of the project, and 
+% create .md files. Each file contains the formatted documentation for 
+% each function that is located under the folders.
+% 
+% Authors: Ryan Topfer, Alexandre D'Astous
+
+%% Initial setup
+% create new temp folder
+!mkdir temp
+cd temp
+
+% Clone shimming-toolbox repos and add to matlab path
+!git clone https://github.com/shimming-toolbox/helpDocMd.git
+
+% might not need it anymore
+% !git clone https://github.com/ewiger/yamlmatlab.git  
+
+addpath(genpath('./helpDocMd/src'))
+addpath(genpath('./yamlmatlab'))
+!git clone https://github.com/shimming-toolbox/shimming-toolbox.git
+addpath(genpath('./shimming-toolbox'))
+
+%% branch
+% Go into repository folder
+% cd shimming-toolbox
+% Create branch called update-website, if it already exists, wont change
+% branch
+!git checkout -b update-website
+% go into it if it previously failed, if not then it does not do anything
+!git checkout update-website
+cd ..
+
+%% API doc
+% delete current shimming-toolbox/docs/contributing/api_documentation/*
+!rm -r shimming-toolbox/docs/contributing/api_documentation
+!mkdir shimming-toolbox/docs/contributing/api_documentation
+
+% Generate API documentation
+src = './shimming-toolbox';
+outputPath = './shimming-toolbox/docs/contributing/api_documentation';
+
+src = Documentor.findfiles( src );
+
+% Remove files not working
+src = src(~contains(src,'shimming-toolbox/Coils/Shim_Siemens/Shim_Prisma/ShimOpt_Prisma.m'));
+src = src(~contains(src,'shimming-toolbox/Coils/Shim_Siemens/Shim_Prisma/Shim_HGM_Prisma/ShimOpt_HGM_Prisma.m'));
+src = src(~contains(src,'shimming-toolbox/Coils/Shim_Siemens/Shim_Prisma/Shim_IUGM_Prisma_fit/ShimOpt_IUGM_Prisma_fit.m'));
+src = src(~contains(src,'shimming-toolbox/Ui/ShimUse.m'));
+
+% Remove files not to be documented
+src = src(~contains(src,'shimming-toolbox/tests'));
+
+% Call documentor
+Options.outputDir = './shimming-toolbox/docs/contributing/api_documentation';
+Dr = Documentor( src , Options ) ;
+
+% Generate documentation
+Dr.printdoc() ;
+
+% Update mkDocs.yml APIdoc navigation automatically using functions from
+% @Documentor.printYml
+
+
+%% README, LICENSE, etc
+
+% Python script that (might as well be matlab at this point?) 
+% - Reads current mkdocs.yml configuration file   Need YAML fix for names
+% with spaces
+% - Looks at shimming-toolbox for the appropriate files
+% -- README will most likely need to be split up
+% -- LICENSE (put where it says in mkdocs.yml)
+% -- Other Ressources (Depending on if it's already in shimming-toolbox.org)
+% - delete them from shimming-toolbox.org
+% - Add them to shimming-toolbox.org
+
+% manual?
+
+%% branch
+% cd shimming-toolbox.org
+% !git add .
+% !git commit -m"Update website"
+% !git push -u origin update-website % (force merge on master eventually?)
+
+%%
+% Delete temp folder and all subfolders
+cd ..
+rmdir temp s
+
+disp('done')
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% General purpose
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% %% Read Yaml file
+% filepath = './shimming-toolbox/mkdocs.yml';
+% configFile = yaml.ReadYaml(filepath);
+% %% Write Yaml file
+% % yaml stores the config file a a data structure, to do so, it needs to
+% % remove the spacings from certain nav fields. The following function
+% % finds those fields and adds the spaces back
+% yaml.WriteYaml('./shimming-toolbox/mkdocs2.yml', configFile);
+% keywords = {'Getting Started'; 'API Documentation'; 'Other Ressources'};
+% correctSpacings('./shimming-toolbox/mkdocs2.yml', keywords)
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% functions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+function correctSpacings(filepath, keywords)
+    
+    % create cell array containing keyword without spaces
+    for i = 1:numel(keywords)
+        noSpacing{i,1} = keywords{i}(~isspace(keywords{i}));
+    end
+    
+    % Read txt into cell A
+    fileID = fopen(filepath,'r');
+    i = 1;
+    while ~feof(fileID)
+        tline = fgetl(fileID);
+        
+        % In a line, look for each keywords
+        for iKeyword = 1:numel(keywords)
+             if(~isempty(strfind(tline,noSpacing{iKeyword})))
+                 
+                 keywordStarts = strfind(tline,noSpacing{iKeyword}) - 1;
+                 
+                 iSpace = 0;
+                 newKeyword = keywords{iKeyword};
+                 spaceInKeyword = strfind(newKeyword,' ') - 1 + iSpace;
+                 while(~isempty(spaceInKeyword))
+                     spaceInTline = keywordStarts + spaceInKeyword ;
+                     tline = [tline(1:spaceInTline), ' ' ,  tline(spaceInTline+1:end)] ;
+                     
+                     newKeyword = [newKeyword(1:spaceInKeyword-iSpace),  newKeyword(spaceInKeyword+2-iSpace:end)]
+                     iSpace = iSpace+1;
+                     spaceInKeyword = strfind(newKeyword,' ') - 1 + iSpace;
+                     
+                 end
+             end
+        end
+
+        newText{i} = tline;
+        i = i+1;
+    end
+    fclose(fileID);
+    
+    % Write newText into txt
+    fileID = fopen(filepath, 'w');
+    for i = 1:numel(newText)
+        if i == numel(newText)
+            fprintf(fileID,'%s', newText{i});
+            break
+        else
+            fprintf(fileID,'%s\n', newText{i});
+        end
+    end
+    fclose(fileID);
+
+end

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Shimming-toolbox
+theme:
+  name: readthedocs
+repo_url: https://github.com/shimming-toolbox/shimming-toolbox
+docs_dir: ./docs
+markdown_extensions:
+  - admonition
+  - extra:
+  - nl2br:
+nav:


### PR DESCRIPTION
Sets up CI that can run against Matlab. We already have an Azure account set up with a self-hosted runner tristano.neuro.polymtl.ca with Matlab installed for https://github.com/qMRLab/qMRLab/.

So, this is #67 but using Azure instead of Github (which is sort of silly since Microsoft built both of them).

It would be nice to add tristano as a [self-hosted Github runner](https://help.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners) because Github Actions is a lot easier to work with from Github than Azure -- **but** for this very large all-caps caveat: 
> Forks of your public repository can potentially run dangerous code on your self-hosted runner machine by creating a pull request that executes the code in a workflow.

Azure prompts for permission to be granted when a pipeline is first run on a given runner. Github Actions apparently hasn't implemented this yet? This seems bizarre; why would forks retain access to private runners? That's got to be wrong, or at least, in the process of becoming wrong. I don't want to be maintaining two CI infrastructures in parallel.

It might be useful to run on both Matlab and Octave, with some tests that depend on Matlab allowed to soft-fail on Octave (for comparison: pytest calls these [xfails](https://docs.pytest.org/en/latest/skipping.html)), since Octave can be parallelized easier and so will give faster feedback, but I don't really know yet; WIP WIP WIP.