### PR TITLE
Create numerical model data for multi-echo field maps

### DIFF
--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -125,9 +125,9 @@ classdef NumericalModel < handle
 
         
         function obj = generate_deltaB0(obj, fieldType, params)       
-            % type: 'linear' or ???
+            % fieldType: 'linear'
             % params: 
-            %    'linear': [m, b, ang] where y = mx + b, and the center of the
+            %    'linear': [m, b] where y = mx + b, and the center of the
             %              volume is the origin. m is Hz per voxel. b is
             %              Hz. ang is the angle against the x axis of the
             %              volume
@@ -137,13 +137,16 @@ classdef NumericalModel < handle
                 case 'linear'
                     m = params(1);
                     b = params(2);
-
+                    
                     dims = size(obj.starting_volume);
 
                     % Create coordinates
                     [X, Y] = meshgrid(linspace(-dims(1), dims(1), dims(1)), linspace(-dims(2), dims(2), dims(2)));
 
                     obj.deltaB0 = m*X+b;
+                    
+                    % Convert field from Hz to T;
+                    obj.deltaB0 = obj.deltaB0 / (obj.gamma / (2*pi));
                 otherwise
                     error('Undefined deltaB0 field type')
             end

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -2,6 +2,9 @@ classdef NumericalModel < handle
     %NUMERICALMODEL Numerical Model for B0 data generation.
     
     properties
+        gamma = 42.58 * 10^6; % Hz/Tesla
+        fieldStrength = 3.0; % Tesla
+        
         starting_volume
         volume
         
@@ -43,7 +46,18 @@ classdef NumericalModel < handle
         end
         
     end
-
+    
+    methods (Static)
+        function signal = generate_signal(protonDensity, T2star, FA, TE, deltaB0, gamma)
+            % FA = flip angle in degrees
+            % T2star in seconds
+            % TE in seconds
+            % B0 in tesla
+            % gamma in Hz/Tesla
+            signal = protonDensity.*sind(FA).*exp(-TE./T2star-1i*gamma*deltaB0.*TE);
+        end
+    end
+    
     methods (Access = protected)
         function customVolume = customize_shepp_logan(obj, volume, class1, class2, class3)
             customVolume = volume;

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -6,7 +6,10 @@ classdef NumericalModel < handle
         volume
         
         % Default times in seconds @ 3T
-        T2star = struct('WM', 0.053, 'GM', 0.066, 'CSF', 0.10) 
+        T2star = struct('WM', 0.053, 'GM', 0.066, 'CSF', 0.10)
+        
+        % Default proton density
+        protonDensity = struct('WM', 70, 'GM', 82, 'CSF', 100)
     end
    
     methods
@@ -31,10 +34,11 @@ classdef NumericalModel < handle
             obj.starting_volume = phantom(dims(1), dims(2));
             
             obj.volume = struct('magn', [], 'phase', [], 'T2star', []);
-            obj.volume.magn = obj.starting_volume;
-            obj.volume.phase = obj.volume.magn * 0;
             
+            obj.volume.magn = obj.customize_shepp_logan(obj.starting_volume, obj.protonDensity.WM, obj.protonDensity.GM, obj.protonDensity.CSF);
+            obj.volume.phase = obj.volume.magn * 0;
             obj.volume.T2star = obj.customize_shepp_logan(obj.starting_volume, obj.T2star.WM, obj.T2star.GM, obj.T2star.CSF);
+
 
         end
         

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -239,7 +239,7 @@ classdef NumericalModel < handle
             customVolume(abs(volume-1)<0.001) = class3;
 
             customVolume((abs(volume)<0.0001)&volume~=0) = class1/2;
-            customVolume(abs(volume-0.1)<0.001) = (class2 - class1/2)/2;
+            customVolume(abs(volume-0.1)<0.001) = (class2 + class1)/2;
             customVolume(abs(volume-0.4)<0.001) = class2*1.5;
         end
     end

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -115,11 +115,27 @@ classdef NumericalModel < handle
             % Get magnitude data
             % fileName: String. Prefix of filename (without extension)
             % saveFormat: 'nifti' (default) or 'mat'
-            
+
             if ~exist('saveFormat', 'var')
+                warning('No save format given - saving to NIfTI')
                 saveFormat = 'nifti'; 
             end
             
+                        
+            if strcmp(fileName(end-3:end), '.nii')
+                if ~strcmp(saveFormat, 'nifti')
+                    warning('File extension and saveFormat do not match - saving to NIfTI format')
+                    saveFormat = 'nifti';
+                end
+                fileName = fileName(1:end-4);
+            elseif strcmp(fileName(end-3:end), '.mat')
+                if ~strcmp(saveFormat, 'mat')
+                    warning('File extension and saveFormat do not match - saving to MAT format')
+                    saveFormat = 'mat';
+                end
+                fileName = fileName(1:end-4);            
+            end
+                        
             switch dataType
                 case 'Magnitude'
                 	vol = obj.getMagnitude();

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -101,6 +101,27 @@ classdef NumericalModel < handle
             vol = imag(obj.measurement);
         end
         
+        function vol = save(obj, dataType, prefix)
+            % Get magnitude data
+            
+            switch dataType
+                case 'Magnitude'
+                	vol = obj.getMagnitude();
+                case 'Phase'
+                	vol = obj.getPhase();
+                case 'Real'
+                	vol = obj.getReal();
+                case 'Imaginary'
+                	vol = obj.getImaginary();
+                otherwise
+                    error('Unknown datatype')
+            end
+            
+            nii_vol = make_nii(imrotate(fliplr(vol), -90));
+            save_nii(nii_vol, prefix);
+        end
+
+        
         function obj = generate_deltaB0(obj, fieldType, params)       
             % type: 'linear' or ???
             % params: 

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -5,18 +5,23 @@ classdef NumericalModel < handle
         gamma = 42.58 * 10^6; % Hz/Tesla
         fieldStrength = 3.0; % Tesla
         
+        % properties
         starting_volume
         volume
+        measurement
         
         % Default times in seconds @ 3T
         T2star = struct('WM', 0.053, 'GM', 0.066, 'CSF', 0.10)
         
-        % Default proton density
+        % Default proton density in percentage
         protonDensity = struct('WM', 70, 'GM', 82, 'CSF', 100)
     end
    
     methods
     	function obj = NumericalModel(model)
+            % NumericalModel class
+            % model: string with the label of the model desired.
+ 
             switch nargin
                 case 0
                     obj.starting_volume = zeros(128, 128);
@@ -33,18 +38,60 @@ classdef NumericalModel < handle
         end
         
         
-        function obj = shepp_logan(obj, dims)          
+        function obj = shepp_logan(obj, dims)       
+            % Create a 2D Shepp_Logan volume for the 
+            % dims: [x, y] number of voxels.
             obj.starting_volume = phantom(dims(1), dims(2));
             
             obj.volume = struct('magn', [], 'phase', [], 'T2star', []);
-            
-            obj.volume.magn = obj.customize_shepp_logan(obj.starting_volume, obj.protonDensity.WM, obj.protonDensity.GM, obj.protonDensity.CSF);
-            obj.volume.phase = obj.volume.magn * 0;
+
+            obj.volume.protonDensity = obj.customize_shepp_logan(obj.starting_volume, obj.protonDensity.WM, obj.protonDensity.GM, obj.protonDensity.CSF);
             obj.volume.T2star = obj.customize_shepp_logan(obj.starting_volume, obj.T2star.WM, obj.T2star.GM, obj.T2star.CSF);
 
 
         end
+
+        function obj = simulate_measurement(obj, FA, TE)          
+            % FA: flip angle value in degrees.
+            % TE: Single or array TE value in seconds.
+            
+            % Get dimensions
+            numTE = length(TE);
+            volDims = size(obj.starting_volume);
+               
+            % Pre-allocate measurement variables
+            deltaB0 = 0*obj.starting_volume; %Temporary
+            if volDims == 2
+                obj.measurement = zeros(volDims(1), volDims(2), 1, numTE);
+            elseif volDims == 3
+                obj.measurement = zeros(volDims(1), volDims(2), volDims(3), numTE);
+            end
+            
+            % Simulate
+            for ii = 1:numTE
+                obj.measurement(:,:,:,ii) = obj.generate_signal(obj.volume.protonDensity, obj.volume.T2star, FA, TE(ii), deltaB0, obj.gamma);
+            end
+        end
         
+        function vol = getMagnitude(obj)
+            % Get magnitude data
+            vol = abs(obj.measurement);
+        end
+        
+        function vol = getPhase(obj)
+            % Get phase data
+            vol = angle(obj.measurement);
+        end
+  
+        function vol = getReal(obj)
+            % Get real data
+            vol = real(obj.measurement);
+        end
+        
+        function vol = getImaginary(obj)
+            % Get imaginary data
+            vol = imag(obj.measurement);
+        end
     end
     
     methods (Static)

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -1,0 +1,28 @@
+classdef NumericalModel
+    %NUMERICALMODEL Numerical Model for B0 data generation.
+    
+    properties
+        starting_volume
+    end
+   
+    methods
+    	function obj = NumericalModel(model)
+            switch nargin
+                case 0
+                    obj.starting_volume = zeros(128, 128);
+                case 1
+                    if strcmp(model, 'Shepp-Logan')
+                        obj.starting_volume = phantom(128, 128);
+                    else
+                        error('Unknown volume model.')
+                    end
+                otherwise
+                    error('Too many input arguments for class.')
+            end
+
+        end
+        
+
+    end
+end
+

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -1,8 +1,12 @@
-classdef NumericalModel
+classdef NumericalModel < handle
     %NUMERICALMODEL Numerical Model for B0 data generation.
     
     properties
         starting_volume
+        volume
+        
+        % Default times in seconds @ 3T
+        T2star = struct('WM', 0.053, 'GM', 0.066, 'CSF', 0.10) 
     end
    
     methods
@@ -12,17 +16,44 @@ classdef NumericalModel
                     obj.starting_volume = zeros(128, 128);
                 case 1
                     if strcmp(model, 'Shepp-Logan')
-                        obj.starting_volume = phantom(128, 128);
+                        obj.shepp_logan([128, 128]);
+                        
                     else
                         error('Unknown volume model.')
                     end
                 otherwise
                     error('Too many input arguments for class.')
             end
+        end
+        
+        
+        function obj = shepp_logan(obj, dims)          
+            obj.starting_volume = phantom(dims(1), dims(2));
+            
+            obj.volume = struct('magn', [], 'phase', [], 'T2star', []);
+            obj.volume.magn = obj.starting_volume;
+            obj.volume.phase = obj.volume.magn * 0;
+            
+            obj.volume.T2star = obj.customize_shepp_logan(obj.starting_volume, obj.T2star.WM, obj.T2star.GM, obj.T2star.CSF);
 
         end
         
-
     end
+
+    methods (Access = protected)
+        function customVolume = customize_shepp_logan(obj, volume, class1, class2, class3)
+            customVolume = volume;
+            
+            % Set regions to T2
+            customVolume(abs(volume-0.2)<0.001) = class1;
+            customVolume(abs(volume-0.3)<0.001) = class2;
+            customVolume(abs(volume-1)<0.001) = class3;
+
+            customVolume((abs(volume)<0.0001)&volume~=0) = class1/2;
+            customVolume(abs(volume-0.1)<0.001) = (class2 - class1/2)/2;
+            customVolume(abs(volume-0.4)<0.001) = class2*1.5;
+        end
+    end
+
 end
 

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -103,7 +103,7 @@ classdef NumericalModel < handle
             vol = imag(obj.measurement);
         end
         
-        function vol = save(obj, dataType, prefix)
+        function vol = save(obj, dataType, niiFilename)
             % Get magnitude data
             
             switch dataType
@@ -120,7 +120,7 @@ classdef NumericalModel < handle
             end
             
             nii_vol = make_nii(imrotate(fliplr(vol), -90));
-            save_nii(nii_vol, prefix);
+            save_nii(nii_vol, niiFilename);
         end
 
         

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -103,8 +103,14 @@ classdef NumericalModel < handle
             vol = imag(obj.measurement);
         end
         
-        function vol = save(obj, dataType, niiFilename)
+        function vol = save(obj, dataType, fileName, saveFormat)
             % Get magnitude data
+            % fileName: String. Prefix of filename (without extension)
+            % saveFormat: 'nifti' (default) or 'mat'
+            
+            if ~exist('saveFormat', 'var')
+                saveFormat = 'nifti'; 
+            end
             
             switch dataType
                 case 'Magnitude'
@@ -119,8 +125,13 @@ classdef NumericalModel < handle
                     error('Unknown datatype')
             end
             
-            nii_vol = make_nii(imrotate(fliplr(vol), -90));
-            save_nii(nii_vol, niiFilename);
+            switch saveFormat
+                case 'nifti'
+                    nii_vol = make_nii(imrotate(fliplr(vol), -90));
+                    save_nii(nii_vol, [fileName '.nii']);
+                case 'mat'
+                    save([fileName '.mat'], 'vol')
+            end
         end
         
         function obj = generate_deltaB0(obj, fieldType, params)       

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -31,10 +31,11 @@ classdef NumericalModel < handle
             end
             
             if exist('model', 'var')
-                if strcmp(model, 'Shepp-Logan')
-                    obj.shepp_logan(obj.numVox);
-                else
-                    error('Unknown volume model.')
+                switch model
+                    case 'Shepp-Logan'
+                    	obj.shepp_logan(obj.numVox);
+                    otherwise
+                        error('Unknown volume model.')
                 end
             else
                 obj.starting_volume = zeros(obj.numVox, obj.numVox);
@@ -155,7 +156,7 @@ classdef NumericalModel < handle
             % T2star in seconds
             % TE in seconds
             % B0 in tesla
-            % gamma in Hz/Tesla
+            % gamma in rad*Hz/Tesla
             signal = protonDensity.*sind(FA).*exp(-TE./T2star-1i*gamma*deltaB0.*TE);
         end
         

--- a/numerical_model/NumericalModel.m
+++ b/numerical_model/NumericalModel.m
@@ -2,10 +2,11 @@ classdef NumericalModel < handle
     %NUMERICALMODEL Numerical Model for B0 data generation.
     
     properties
-        gamma = 42.58 * 10^6; % Hz/Tesla
+        gamma = 267.52218744 * 10^6; % rad*Hz/Tesla
         fieldStrength = 3.0; % Tesla
         
         % properties
+        numVox = 128; % square volume
         starting_volume
         volume
         measurement
@@ -21,22 +22,22 @@ classdef NumericalModel < handle
     end
    
     methods
-    	function obj = NumericalModel(model)
+    	function obj = NumericalModel(model, numVox)
             % NumericalModel class
             % model: string with the label of the model desired.
- 
-            switch nargin
-                case 0
-                    obj.starting_volume = zeros(128, 128);
-                case 1
-                    if strcmp(model, 'Shepp-Logan')
-                        obj.shepp_logan([128, 128]);
-                        
-                    else
-                        error('Unknown volume model.')
-                    end
-                otherwise
-                    error('Too many input arguments for class.')
+            
+            if exist('numVox', 'var')
+            	obj.numVox = numVox;
+            end
+            
+            if exist('model', 'var')
+                if strcmp(model, 'Shepp-Logan')
+                    obj.shepp_logan(obj.numVox);
+                else
+                    error('Unknown volume model.')
+                end
+            else
+                obj.starting_volume = zeros(obj.numVox, obj.numVox);
             end
             
             % Define background field
@@ -44,10 +45,10 @@ classdef NumericalModel < handle
         end
         
         
-        function obj = shepp_logan(obj, dims)       
+        function obj = shepp_logan(obj, numVox)       
             % Create a 2D Shepp_Logan volume for the 
             % dims: [x, y] number of voxels.
-            obj.starting_volume = phantom(dims(1), dims(2));
+            obj.starting_volume = phantom(numVox);
             
             obj.volume = struct('magn', [], 'phase', [], 'T2star', []);
 

--- a/tests/runTestSuite.m
+++ b/tests/runTestSuite.m
@@ -1,0 +1,12 @@
+function [testsResults] = runTestSuite(suiteTag)
+%runtests: Run tagged tests from all subdirectories
+%   suiteTag: String matching tags from test classes in subdirectories
+%
+% Example usage:
+% result = runtests(pwd, 'Recursively', true)
+% result = runTestSuite('Unit')
+    import matlab.unittest.TestSuite;
+    fullSuite = TestSuite.fromFolder(pwd, 'IncludingSubfolders', true);
+    persistenceSuite = fullSuite.selectIf('Tag',suiteTag);
+    testsResults = run(persistenceSuite)
+end

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -68,7 +68,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.T2star.GM));
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-1)<0.001) == testObj.T2star.CSF));
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.T2star.WM/2));
-            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.1)<0.001) == (testObj.T2star.GM - testObj.T2star.WM/2)/2));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.1)<0.001) == (testObj.T2star.GM + testObj.T2star.WM)/2));
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.4)<0.001) == testObj.T2star.GM * 1.5));
         end
         
@@ -79,7 +79,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.protonDensity.GM));
             testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-1)<0.001) == testObj.protonDensity.CSF));
             testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.protonDensity.WM/2));
-            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.1)<0.001) == (testObj.protonDensity.GM - testObj.protonDensity.WM/2)/2));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.1)<0.001) == (testObj.protonDensity.GM + testObj.protonDensity.WM)/2));
             testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.4)<0.001) == testObj.protonDensity.GM * 1.5));
         end
 

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -90,6 +90,28 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(isreal(testObj.getImaginary()));
          end
         
+         function test_simulate_signal_SNR_results_in_noisy_backgroun(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 15;
+            TE = [0.003 0.015];
+            SNR = 50;
+            
+            testObj.simulate_measurement(FA, TE, SNR);
+            
+            magnitudeData = testObj.getMagnitude;            
+            vecMagnitudeROI = magnitudeData(1:10, 1:10, 1, 1);
+            vecMagnitudeROI = vecMagnitudeROI(:);
+
+            testCase.assertTrue(std(vecMagnitudeROI)~=0);
+            
+            phaseData = testObj.getPhase;
+            vecPhaseROI = phaseData(1:10, 1:10, 1, 1);
+            vecPhaseROI = vecPhaseROI(:);
+
+            testCase.assertTrue(std(vecPhaseROI)~=0);
+         end
+         
         %% generate_signal method tests
         function test_generate_signal_case_1(testCase)
             

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -1,7 +1,7 @@
 classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unittest.TestCase
 
     properties
-        testFileName = 'test.nii'
+        testFileName = 'test'
     end
 
     methods (TestClassSetup)
@@ -9,8 +9,11 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
 
     methods (TestClassTeardown)
         function removeTempFolder(testCase)
-            if isfile(testCase.testFileName)
-                delete(testCase.testFileName)
+            if isfile([testCase.testFileName '.nii'])
+                delete([testCase.testFileName '.nii'])
+            end
+             if isfile([testCase.testFileName '.mat'])
+                delete([testCase.testFileName '.mat'])
             end
         end
     end
@@ -202,7 +205,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
         end
         
         %% save method tests
-        function test_save(testCase)
+        function test_save_nii(testCase)
             testObj = NumericalModel('Shepp-Logan');
             
             FA = 15;
@@ -210,11 +213,24 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
 
             testObj.simulate_measurement(FA, TE);
                         
-            testObj.save('Phase', testCase.testFileName);
+            testObj.save('Phase', testCase.testFileName); % Default option for save is a NIfTI output.
   
-            testCase.assertTrue(isfile(testCase.testFileName))
+            testCase.assertTrue(isfile([testCase.testFileName, '.nii']))
         end
+
         
+        function test_save_mat(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 15;
+            TE = [0.003 0.015];
+
+            testObj.simulate_measurement(FA, TE);
+                        
+            testObj.save('Phase', testCase.testFileName, 'mat');
+  
+            testCase.assertTrue(isfile([testCase.testFileName, '.mat']))
+        end
         %% generate_signal method tests
         function test_generate_signal_case_1(testCase)
             

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -62,6 +62,55 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
 
             testCase.assertTrue(all(all(testObj.volume.phase == 0)));
         end
+
+        function test_generate_signal_case_1(testCase)
+            
+            protonDensity = 80;
+            
+            T2star = 100;
+            FA = 90;
+            TE = 0;
+            deltaB0 = 0;
+            gamma = 42.58 * 10^6;
+            
+            actual_signal = NumericalModel.generate_signal(protonDensity, T2star, FA, TE, deltaB0, gamma);
+            expected_signal = protonDensity;
+            
+            testCase.verifyEqual(actual_signal, expected_signal);
+        end
+
+        function test_generate_signal_case_2(testCase)
+            
+            FA = 0;
+            
+            protonDensity = 80;
+            T2star = 100;
+            TE = 0;
+            deltaB0 = 0;
+            gamma = 42.58 * 10^6;
+            
+            actual_signal = NumericalModel.generate_signal(protonDensity, T2star, FA, TE, deltaB0, gamma);
+            expected_signal = 0;
+            
+            testCase.verifyEqual(actual_signal, expected_signal);
+        end
+
+        
+        function test_generate_signal_case_3(testCase)
+            
+            FA = 20;
+            protonDensity = 80;
+            T2star = 100;
+            TE = 0.010;
+            deltaB0 = 2;
+            gamma = 42.58 * 10^6;
+            
+            actual_signal = NumericalModel.generate_signal(protonDensity, T2star, FA, TE, deltaB0, gamma);
+            expected_signal = protonDensity.*sind(FA).*exp(-TE./T2star-1i*gamma*deltaB0.*TE);
+            
+            testCase.assertTrue(~isreal(expected_signal))
+            testCase.verifyEqual(actual_signal, expected_signal);
+        end
     end
 
 end

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -35,14 +35,23 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
         end
  
         %% Shepp-Logan type tests instance test
-        function test_shepplogan_initialization_returns_expected_starting_volume(testCase)
+        function test_shepplogan_emtpy_init_returns_expected_starting_volume(testCase)
             testObj = NumericalModel('Shepp-Logan');
 
-            expectedVolume = phantom(128, 128);
+            expectedVolume = phantom(128);
             actualVolume = testObj.starting_volume;
             testCase.verifyEqual(actualVolume, expectedVolume)
         end
  
+         function test_shepplogan_dims_init_returns_expected_starting_volume(testCase)
+            dims = 256;
+            testObj = NumericalModel('Shepp-Logan', dims);
+
+            expectedVolume = phantom(dims);
+            actualVolume = testObj.starting_volume;
+            testCase.verifyEqual(actualVolume, expectedVolume)
+        end
+        
         function test_shepp_logan_defines_expected_t2star_values(testCase)
             testObj = NumericalModel('Shepp-Logan');
 

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -10,6 +10,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
     end
 
     methods (Test)
+        %% Class instance tests
         function test_initiate_object_is_expected_class(testCase)
 
             testObj = NumericalModel();
@@ -27,6 +28,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.verifyEqual(actualVolume, expectedVolume)
         end
  
+        %% Shepp-Logan type tests instance test
         function test_shepplogan_initialization_returns_expected_starting_volume(testCase)
             testObj = NumericalModel('Shepp-Logan');
 
@@ -49,20 +51,46 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
         function test_shepp_logan_defines_expected_magnitude_values(testCase)
             testObj = NumericalModel('Shepp-Logan');
 
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.2)<0.001) == testObj.protonDensity.WM));
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.protonDensity.GM));
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-1)<0.001) == testObj.protonDensity.CSF));
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.protonDensity.WM/2));
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.1)<0.001) == (testObj.protonDensity.GM - testObj.protonDensity.WM/2)/2));
-            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.4)<0.001) == testObj.protonDensity.GM * 1.5));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.2)<0.001) == testObj.protonDensity.WM));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.protonDensity.GM));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-1)<0.001) == testObj.protonDensity.CSF));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.protonDensity.WM/2));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.1)<0.001) == (testObj.protonDensity.GM - testObj.protonDensity.WM/2)/2));
+            testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.4)<0.001) == testObj.protonDensity.GM * 1.5));
         end
- 
-        function test_shepp_logan_defines_expected_zero_initial_phase(testCase)
+
+        %% simulate_signal method tests
+        
+        function test_simulate_signal_returns_expected_volume_size(testCase)
             testObj = NumericalModel('Shepp-Logan');
-
-            testCase.assertTrue(all(all(testObj.volume.phase == 0)));
+            
+            FA = 15;
+            TE = [0.003 0.015];
+            
+            
+            testObj.simulate_measurement(FA, TE);
+                        
+            expectedDims = [128, 128, 1, length(TE)];
+            actualDims = size(testObj.measurement);
+            testCase.verifyEqual(actualDims, expectedDims);
         end
-
+          
+         function test_getFunctions_returns_volume_of_expected_datatype(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 15;
+            TE = [0.003 0.015];
+            
+            
+            testObj.simulate_measurement(FA, TE);
+            
+            testCase.assertTrue(isreal(testObj.getMagnitude()));
+            testCase.assertTrue(isreal(testObj.getPhase()));
+            testCase.assertTrue(isreal(testObj.getReal()));
+            testCase.assertTrue(isreal(testObj.getImaginary()));
+         end
+        
+        %% generate_signal method tests
         function test_generate_signal_case_1(testCase)
             
             protonDensity = 80;
@@ -95,7 +123,6 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.verifyEqual(actual_signal, expected_signal);
         end
 
-        
         function test_generate_signal_case_3(testCase)
             
             FA = 20;

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -34,6 +34,18 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             actualVolume = testObj.starting_volume;
             testCase.verifyEqual(actualVolume, expectedVolume)
         end
+ 
+        function test_shepp_logan_defines_expected_t2star_values(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.2)<0.001) == testObj.T2star.WM));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.T2star.GM));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-1)<0.001) == testObj.T2star.CSF));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.T2star.WM/2));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.1)<0.001) == (testObj.T2star.GM - testObj.T2star.WM/2)/2));
+            testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.4)<0.001) == testObj.T2star.GM * 1.5));
+
+        end
     end
 
 end

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -44,7 +44,23 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.T2star.WM/2));
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.1)<0.001) == (testObj.T2star.GM - testObj.T2star.WM/2)/2));
             testCase.assertTrue(all(testObj.volume.T2star(abs(testObj.starting_volume-0.4)<0.001) == testObj.T2star.GM * 1.5));
+        end
+        
+        function test_shepp_logan_defines_expected_magnitude_values(testCase)
+            testObj = NumericalModel('Shepp-Logan');
 
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.2)<0.001) == testObj.protonDensity.WM));
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.3)<0.001) ==  testObj.protonDensity.GM));
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-1)<0.001) == testObj.protonDensity.CSF));
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume)<0.001&testObj.starting_volume~=0) == testObj.protonDensity.WM/2));
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.1)<0.001) == (testObj.protonDensity.GM - testObj.protonDensity.WM/2)/2));
+            testCase.assertTrue(all(testObj.volume.magn(abs(testObj.starting_volume-0.4)<0.001) == testObj.protonDensity.GM * 1.5));
+        end
+ 
+        function test_shepp_logan_defines_expected_zero_initial_phase(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+
+            testCase.assertTrue(all(all(testObj.volume.phase == 0)));
         end
     end
 

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -1,12 +1,18 @@
 classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unittest.TestCase
 
     properties
+        testFileName = 'test.nii'
     end
 
     methods (TestClassSetup)
     end
 
     methods (TestClassTeardown)
+        function removeTempFolder(testCase)
+            if isfile(testCase.testFileName)
+                delete(testCase.testFileName)
+            end
+        end
     end
 
     methods (Test)
@@ -142,7 +148,22 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
 
             testCase.assertTrue(std(vecPhaseROI)~=0);
          end
+
          
+        %% save method tests
+        function test_save(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 15;
+            TE = [0.003 0.015];
+
+            testObj.simulate_measurement(FA, TE);
+                        
+            testObj.save('Phase', testCase.testFileName);
+  
+            testCase.assertTrue(isfile(testCase.testFileName))
+        end
+        
         %% generate_signal method tests
         function test_generate_signal_case_1(testCase)
             
@@ -191,6 +212,7 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(~isreal(expected_signal))
             testCase.verifyEqual(actual_signal, expected_signal);
         end
+        
     end
 
 end

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -59,6 +59,37 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testCase.assertTrue(all(testObj.volume.protonDensity(abs(testObj.starting_volume-0.4)<0.001) == testObj.protonDensity.GM * 1.5));
         end
 
+        
+        %% simulate_signal method tests
+        
+        function test_generate_deltaB0_linear_floor_value(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            m = 0;
+            b = 2;
+            testObj.generate_deltaB0('linear', [m b]);
+            
+            deltaB0_map = testObj.deltaB0;
+            
+            testCase.verifyEqual(mean(deltaB0_map(:)), b);
+        end
+        
+        
+        function test_generate_deltaB0_linear_slope_value(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            m = 1;
+            b = 0;
+            testObj.generate_deltaB0('linear', [m b]);
+            
+            deltaB0_map = testObj.deltaB0;
+            
+            dims = size(deltaB0_map);
+            [X, Y] = meshgrid(linspace(-dims(1), dims(1), dims(1)), linspace(-dims(2), dims(2), dims(2)));
+
+            testCase.verifyEqual(deltaB0_map(round(dims(1)/2), round(dims(1)/4)), m*X(round(dims(1)/2), round(dims(1)/4)));
+        end
+        
         %% simulate_signal method tests
         
         function test_simulate_signal_returns_expected_volume_size(testCase)

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -12,8 +12,12 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             if isfile([testCase.testFileName '.nii'])
                 delete([testCase.testFileName '.nii'])
             end
-             if isfile([testCase.testFileName '.mat'])
+            if isfile([testCase.testFileName '.mat'])
                 delete([testCase.testFileName '.mat'])
+            end
+            
+            if isfile([testCase.testFileName '.json'])
+                delete([testCase.testFileName '.json'])
             end
         end
     end
@@ -216,20 +220,37 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             testObj.save('Phase', testCase.testFileName); % Default option for save is a NIfTI output.
   
             testCase.assertTrue(isfile([testCase.testFileName, '.nii']))
+            
+            
+            % Verify that JSON was written correctly
+            testCase.assertTrue(isfile([testCase.testFileName, '.json']))
+            
+            fname = [testCase.testFileName, '.json'];
+            val = jsondecode(fileread(fname));
+            testCase.verifyEqual(val.EchoTime', TE)
+            testCase.verifyEqual(val.FlipAngle', FA)
         end
 
         
         function test_save_mat(testCase)
             testObj = NumericalModel('Shepp-Logan');
             
-            FA = 15;
-            TE = [0.003 0.015];
+            FA = 20;
+            TE = [0.003 0.025];
 
             testObj.simulate_measurement(FA, TE);
                         
             testObj.save('Phase', testCase.testFileName, 'mat');
   
             testCase.assertTrue(isfile([testCase.testFileName, '.mat']))
+            
+            % Verify that JSON was written correctly
+            testCase.assertTrue(isfile([testCase.testFileName, '.json']))
+            
+            fname = [testCase.testFileName, '.json'];
+            val = jsondecode(fileread(fname));
+            testCase.verifyEqual(val.EchoTime', TE)
+            testCase.verifyEqual(val.FlipAngle', FA)
         end
         %% generate_signal method tests
         function test_generate_signal_case_1(testCase)

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -2,6 +2,8 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
 
     properties
         testFileName = 'test'
+        testFileNameNii = 'test.nii'
+        testFileNameMat = 'test.mat'
     end
 
     methods (TestClassSetup)
@@ -229,8 +231,46 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             val = jsondecode(fileread(fname));
             testCase.verifyEqual(val.EchoTime', TE)
             testCase.verifyEqual(val.FlipAngle', FA)
+            
+            
+            if isfile([testCase.testFileName '.nii'])
+                delete([testCase.testFileName '.nii'])
+            end
+            if isfile([testCase.testFileName '.json'])
+                delete([testCase.testFileName '.json'])
+            end
         end
 
+        %% save method tests
+        function test_save_nii_with_extension(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 15;
+            TE = [0.003 0.015];
+
+            testObj.simulate_measurement(FA, TE);
+                        
+            testObj.save('Phase', [testCase.testFileName, '.nii']); % Default option for save is a NIfTI output.
+  
+            testCase.assertTrue(isfile([testCase.testFileName, '.nii']))
+            
+            
+            % Verify that JSON was written correctly
+            testCase.assertTrue(isfile([testCase.testFileName, '.json']))
+            
+            fname = [testCase.testFileName, '.json'];
+            val = jsondecode(fileread(fname));
+            testCase.verifyEqual(val.EchoTime', TE)
+            testCase.verifyEqual(val.FlipAngle', FA)
+            
+            
+            if isfile([testCase.testFileName '.nii'])
+                delete([testCase.testFileName '.nii'])
+            end
+            if isfile([testCase.testFileName '.json'])
+                delete([testCase.testFileName '.json'])
+            end
+        end
         
         function test_save_mat(testCase)
             testObj = NumericalModel('Shepp-Logan');
@@ -251,7 +291,43 @@ classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unitte
             val = jsondecode(fileread(fname));
             testCase.verifyEqual(val.EchoTime', TE)
             testCase.verifyEqual(val.FlipAngle', FA)
+            
+            if isfile([testCase.testFileName '.mat'])
+                delete([testCase.testFileName '.mat'])
+            end
+            if isfile([testCase.testFileName '.json'])
+                delete([testCase.testFileName '.json'])
+            end
         end
+        
+        function test_save_mat_with_extension(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+            
+            FA = 20;
+            TE = [0.003 0.025];
+
+            testObj.simulate_measurement(FA, TE);
+                        
+            testObj.save('Phase', [testCase.testFileName, '.mat'], 'mat');
+  
+            testCase.assertTrue(isfile([testCase.testFileName, '.mat']))
+            
+            % Verify that JSON was written correctly
+            testCase.assertTrue(isfile([testCase.testFileName, '.json']))
+            
+            fname = [testCase.testFileName, '.json'];
+            val = jsondecode(fileread(fname));
+            testCase.verifyEqual(val.EchoTime', TE)
+            testCase.verifyEqual(val.FlipAngle', FA)
+            
+            if isfile([testCase.testFileName '.mat'])
+                delete([testCase.testFileName '.mat'])
+            end
+            if isfile([testCase.testFileName '.json'])
+                delete([testCase.testFileName '.json'])
+            end
+        end
+        
         %% generate_signal method tests
         function test_generate_signal_case_1(testCase)
             

--- a/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
+++ b/tests/shimming-toolbox/numerical_model/NumericalModel_Test.m
@@ -1,0 +1,39 @@
+classdef (TestTags = {'Simulation', 'Unit'}) NumericalModel_Test < matlab.unittest.TestCase
+
+    properties
+    end
+
+    methods (TestClassSetup)
+    end
+
+    methods (TestClassTeardown)
+    end
+
+    methods (Test)
+        function test_initiate_object_is_expected_class(testCase)
+
+            testObj = NumericalModel();
+
+            expectedClass = 'NumericalModel';
+            actualClass = class(testObj);
+            testCase.verifyEqual(actualClass, expectedClass)
+        end
+ 
+        function test_empty_initialization_returns_expected_starting_volume(testCase)
+            testObj = NumericalModel();
+
+            expectedVolume = zeros(128, 128);
+            actualVolume = testObj.starting_volume;
+            testCase.verifyEqual(actualVolume, expectedVolume)
+        end
+ 
+        function test_shepplogan_initialization_returns_expected_starting_volume(testCase)
+            testObj = NumericalModel('Shepp-Logan');
+
+            expectedVolume = phantom(128, 128);
+            actualVolume = testObj.starting_volume;
+            testCase.verifyEqual(actualVolume, expectedVolume)
+        end
+    end
+
+end


### PR DESCRIPTION
Resolves #102 

I think I've done enough here to warrant a sanity check to make sure I'm going in the right track. for this hackathon project. Likely not actually ready for a full PR review, just wanted to start a discussion here.

* I've created a class to for the simulations, `NumericalModel`
* If initialized with a string parameter, it will define the volume geometry associated to that key.
  * So far, I've only implemented a 2D Shepp-Logan phantom, with key `Shepp-Logan`
  * The phantom associates T2star and proton density values. I've defined some default ones for now.

<img width="431" alt="Capture d’écran 2020-06-16 à 23 51 05" src="https://user-images.githubusercontent.com/1421029/84847700-43c11b80-b02c-11ea-87a3-0d13bb2f753c.png">

* By default, the background delta B0 is set to 0, but you can define one with the method `generate_deltaB0` after creating an instance of the class.
  * So far, I've only created a linear field in the X direction (mx+b)
  * Example usage: `obj_name.generate_deltaB0('linear', [m, b])`  where m and b are single values.

<img width="440" alt="Capture d’écran 2020-06-16 à 23 52 17" src="https://user-images.githubusercontent.com/1421029/84847789-70753300-b02c-11ea-9963-6c7d6ff760be.png">

* After doing so, you can generate a 4D measurement volume (4th volume is different TEs)
  * These are treated as separate/independent measurements in the signal model.
  * Can TE can be an array
  * You can optionally define SNR to add noise during the method call.
  * There are some `get` functions to get the magnitude/phase/real/imaginary volumes of your choice.

Example call:

```MATLAB
test_obj=NumericalModel('Shepp-Logan');
test_obj.generate_deltaB0('linear', [0.05 0.01]);
test_obj.simulate_measurement(15, [0.001 0.015], 10);
magn = test_obj.getMagnitude;
phase = test_obj.getPhase;
figure(),imagesc(magn(:,:,1,1))
figure(),imagesc(phase(:,:,1,1))
```

<img width="1114" alt="Capture d’écran 2020-06-16 à 23 55 47" src="https://user-images.githubusercontent.com/1421029/84848032-f42f1f80-b02c-11ea-899e-c3d3914086b8.png">
 
  * You can export your simulated volume to NIFTI using the `save` method
    * Example call: `test_obj.save('Magnitude', 'simulated_magnitude.nii');`

Opened in FSLeyes:

<img width="1293" alt="Capture d’écran 2020-06-17 à 00 00 19" src="https://user-images.githubusercontent.com/1421029/84848366-90592680-b02d-11ea-8ffc-0699225460da.png">

Lastly, for all the code I wrote, I wrote tests for them. Since I didn't see many tests to base myself off of in your master branch, I used what I felt comfortable with, which is MATLAB's class-based unit test and tags workflow. You can run them by (after adding all the repo's folders to your MATLAB path) opening the tests directory and running `result = runtests(pwd, 'Recursively', true)`.

```MATLAB
>> result = runtests(pwd, 'Recursively', true)
Running NumericalModel_Test
.......... ....
Done NumericalModel_Test
__________


result = 

  1×14 TestResult array with properties:

    Name
    Passed
    Failed
    Incomplete
    Duration
    Details

Totals:
   14 Passed, 0 Failed, 0 Incomplete.
   0.42035 seconds testing time.

>> 
```

