### PR TITLE
Update azure-pipeline CI and website generation triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ steps:
     chmod 755 generate-docs.sh
     ./generate-docs.sh
   displayName: 'Generate and publish website'
-  condition: and(succeeded(),ne(variables['Build.Reason'],'IndividualCI'))
+  condition: and(succeeded(),eq(variables['Build.Reason'],'IndividualCI'))
   env:
     GH_PAGES_TOKEN: $(GH_PAGES_TOKEN)
     CUSTOM_DOMAIN: www.shimming-toolbox.org

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,30 +3,19 @@
 trigger:
 - master
 
-# Specifying nothing is the same as this for PRs:
-# pr:
-# - *
+# If there is a push on a PR, it wont do run
+pr: none
 
 # use the self-hosted runner at tristano.neuro.polymtl.ca
 # this has Matlab installed and a license to use it.
 pool: 'Default'
 
 steps:
-# Build condition : IndividualCI is a trigger (trigger only happens on master merge/push)
-# If there is a push on a PR, it wont do this step.
+
 - script: |
     chmod 755 generate-docs.sh
     ./generate-docs.sh
   displayName: 'Generate and publish website'
-  condition: and(succeeded(),eq(variables['Build.Reason'],'IndividualCI'))
   env:
     GH_PAGES_TOKEN: $(GH_PAGES_TOKEN)
     CUSTOM_DOMAIN: www.shimming-toolbox.org
-# Always do this step
-- script: |
-    # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
-    # And worse, our Matlab license only allows one process at a time (TODO: verify this),
-    # so a forgotten `quit` will block all tests on all branches.
-    # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
-    matlab -nodisplay -nosplash -r "disp('Unit tests!'); quit"
-  displayName: 'Unit Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,10 +15,10 @@ steps:
 # Build condition : IndividualCI is a trigger (trigger only happens on master merge/push)
 # If there is a push on a PR, it wont do this step.
 - script: |
-  condition: and(succeeded(),ne(variables['Build.Reason'],'IndividualCI'))
     chmod 755 generate-docs.sh
     ./generate-docs.sh
   displayName: 'Generate and publish website'
+  condition: and(succeeded(),ne(variables['Build.Reason'],'IndividualCI'))
   env:
     GH_PAGES_TOKEN: $(GH_PAGES_TOKEN)
     CUSTOM_DOMAIN: www.shimming-toolbox.org

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,6 @@ trigger:
 # this has Matlab installed and a license to use it.
 pool: 'Default'
 
-jobs:
-
 steps:
 # Build condition : IndividualCI is a trigger (trigger only happens on master merge/push)
 # If there is a push on a PR, it wont do this step.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,26 +1,34 @@
 # Run generate-docs script.
 
-# TODO: push on master shimming-toolbox
 trigger:
 - master
+
+# Specifying nothing is the same as this for PRs:
+# pr:
+# - *
 
 # use the self-hosted runner at tristano.neuro.polymtl.ca
 # this has Matlab installed and a license to use it.
 pool: 'Default'
 
-steps:
+jobs:
 
+steps:
+# Build condition : IndividualCI is a trigger (trigger only happens on master merge/push)
+# If there is a push on a PR, it wont do this step.
 - script: |
+  condition: and(succeeded(),ne(variables['Build.Reason'],'IndividualCI'))
     chmod 755 generate-docs.sh
     ./generate-docs.sh
   displayName: 'Generate and publish website'
   env:
     GH_PAGES_TOKEN: $(GH_PAGES_TOKEN)
     CUSTOM_DOMAIN: www.shimming-toolbox.org
-#- script: |
+# Always do this step
+- script: |
     # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
     # And worse, our Matlab license only allows one process at a time (TODO: verify this),
     # so a forgotten `quit` will block all tests on all branches.
     # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
-#    matlab -nodisplay -nosplash -r "disp('Unit tests!'); quit"
-#  displayName: 'Unit Tests'
+    matlab -nodisplay -nosplash -r "disp('Unit tests!'); quit"
+  displayName: 'Unit Tests'

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -1,0 +1,22 @@
+# Run CI.
+
+trigger:
+- master
+
+# Specifying nothing is the same as this for PRs:
+# pr:
+# - *
+
+# use the self-hosted runner at tristano.neuro.polymtl.ca
+# this has Matlab installed and a license to use it.
+pool: 'Default'
+
+steps:
+
+- script: |
+    # Beware: you MUST put `quit` at the end; Matlab does not auto-quit.
+    # And worse, our Matlab license only allows one process at a time (TODO: verify this),
+    # so a forgotten `quit` will block all tests on all branches.
+    # https://www.mathworks.com/matlabcentral/answers/523194-matlab-script-in-batch-from-unix-command-line
+    matlab -nodisplay -nosplash -r "disp('Unit tests!'); quit"
+  displayName: 'Unit Tests'


### PR DESCRIPTION
The purpose of this PR is to set up the trigger the website generation when master is merged and add back the continuous integration on PRs with comments and on merge to master.

Fixes #135 