### PR TITLE
Established convention for docstrings

### DIFF
--- a/+imutils/dicom_to_nifti.m
+++ b/+imutils/dicom_to_nifti.m
@@ -1,14 +1,41 @@
-function dicom_to_nifti( unsortedDicomDir, niftiPath )
-%DICOM_TO_NIFTI converts dicoms into niftis with dcm2bids output 
+function dicom_to_nifti(unsortedDicomDir, niftiPath)
+%% DICOM_TO_NIFTI converts DICOM data to organized NIfTI files.
+% 
+% This function uses <https://github.com/cbedetti/Dcm2Bids dcm2bids> to 
+% convert all DICOM files within a directory, into NIfTI 
+% 
+% SYNTAX:
+% 
+%     dicom_to_nifti(unsortedDicomDir, niftiPath)
 %
-%   dicom_to_nifti( unsortedDicomDir, niftiPath )
+% INPUTS:
 %
-% The input `unsortedDicomDir` is a path to a folder containing either be 
-% ".dcm" or ".IMA". The input `iftiPath`is a folder for the output. 
+%   unsortedDicomDir (str):
+%     Path to a folder containing either be ".dcm" or ".IMA".
+% 
+%   niftiPath (str):
+%     Output folder that will enclose the converted NIfTI files.
 %
-% The output will be niftis in seperate folders according to their
-% acquisition names that are in `niftiPath`.
-
+% OUTPUTS:
+% 
+%   None
+% 
+% EXAMPLE:
+% 
+%     dicom_to_nifti('/home/bob/data_dicom', '/home/bob/data_nii_bids')
+% 
+% DEPENDENCIES:
+% 
+%   <https://github.com/cbedetti/Dcm2Bids dcm2bids>
+%   
+%   <https://github.com/rordenlab/dcm2niix dcm2niix>
+% 
+% AUTHORS:
+% 
+%   Ryan Topfer <topfer@ualberta.ca>
+%   
+%   Alexandre D'Astous <adastous023@gmail.com>
+%%
 mkdir(niftiPath);
 disp(unsortedDicomDir);
 disp(niftiPath);
@@ -109,11 +136,11 @@ for iAcq = 1:length(acquisitionNames)
 end
 
 end
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Local functions
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
 function filePath = createConfig(outputDir, acquisitionNumber, acquisitionName, modality)
-    
+% Create config for blablabla (to be continued...)
+
 % Create names
 name = [acquisitionNumber '_' acquisitionName];
 ext = '.json';

--- a/external/genToolboxHelp.m
+++ b/external/genToolboxHelp.m
@@ -57,15 +57,16 @@ function FileList = genToolboxHelp(ToolBoxPath, ToolBoxName, IgnoredFolders, eva
 % August 2015; Last revision: 31-Aug-2015
 % Copyright 2014-2015 Johannes Milvich
 %------------- BEGIN CODE --------------% 
+
+global MAKECONTENTSFILES; MAKECONTENTSFILES = false;  % Create Contents.m file within each folder.
+global FOLDERHTML; FOLDERHTML = 'html';  % Folder name for output html files.
+global PUBLISHSHOWCODE; PUBLISHSHOWCODE = false;  % show code in published html
+
 %% 1) Initialisation
 % Check inputs - if no ignored folders are specified, only the default ones
 % (.git and the Help folder itself) are ignored. By default, the code is not
 % evaluated for the published .m files and a searchable database is
 % created. Also check if the specified ToolBoxpath exists.
-global MAKECONTENTSFILES
-MAKECONTENTSFILES = false;  % Create Contents.m file within each folder.
-global FOLDERHTML
-FOLDERHTML = 'html';  % Folder name for output html files.
 
 if nargin<3
     IgnoredFolders = {};
@@ -637,12 +638,13 @@ function status = updateHtmlFile(m_file_name, help_folder_name, rootDir)
 % email address: Johannes.Milvich@de.bosch.com
 % August 2015; Last revision: 31-Aug-2015
 % Copyright 2014-2015 Johannes Milvich
+global PUBLISHSHOWCODE
 help_file_name = strrep(strrep(m_file_name,rootDir,''),'.m','.html');
 help_file_name_fp = fullfile(help_folder_name,help_file_name);
 if ~exist(help_file_name_fp,'file')
     % If a helpfile of that name does not exist yet, directly
     % publish it to the right folder
-    publish(m_file_name, 'format','html','outputDir',help_folder_name,'evalCode',false);
+    publish(m_file_name, 'format','html','outputDir',help_folder_name,'evalCode',false, 'showCode', PUBLISHSHOWCODE);
     status = 1;
 else
     % If a helpfile of that name already exists, publish to a
@@ -652,7 +654,7 @@ else
     % keep the old one
     tmp_folder = fullfile(help_folder_name,'tmp');
     mkdir(tmp_folder);
-    tmp_help_file_name_fp = publish(m_file_name, 'format','html','outputDir',tmp_folder,'evalCode',false);
+    tmp_help_file_name_fp = publish(m_file_name, 'format','html','outputDir',tmp_folder,'evalCode',false, 'showCode', PUBLISHSHOWCODE);
     
     [status,~] = system(['fc ' tmp_help_file_name_fp ' ' help_file_name_fp]);
     if status


### PR DESCRIPTION
This PR establishes conventions for headers of .m files in this project. 

Initially, the strategy was to modify [genToolboxHelp](https://github.com/shimming-toolbox/shimming-toolbox/blob/master/external/genToolboxHelp.m) to modify each .m file to match the formatting needs for Matlab's documentation browser. However, after giving it some thoughts, a better strategy consists in modifying the excellent [helpDocMd](https://github.com/shimming-toolbox/helpDocMd) to accommodate different formatting outputs. 

Fixes #133 
Related to https://github.com/shimming-toolbox/helpDocMd/issues/5