### PR TITLE
BUG: resliceimg (MaRdI interpolation) issue #161

### DIFF
--- a/Img/MaRdI.m
+++ b/Img/MaRdI.m
@@ -1235,41 +1235,32 @@ elseif nargin >= 5
     end
 end
 
-isUsingScatteredInterpolant = [] ;
-
-if (ndims(Img.img) > 1) && (ndims(Img.img) <= 5)
-
-    gridSizeIp = Img.getgridsize() ;
-    
-    if gridSizeIp(3) > 1
-        isUsingScatteredInterpolant = true ;
-    else
-        isUsingScatteredInterpolant = false ;
-    end
-else
-    error('Dimensions of input Img.img must be >= 2, and <= 5') ;
-end
+assert( [ndims(Img.img) >= 2] & [ndims(Img.img) <= 5],...
+    'Dimensions of input Img.img must be >= 2, and <= 5') ;
 
 % -----------------
 %% Define variables
+gridSizeIp = Img.getgridsize();
+
+if gridSizeIp(3) > 1
+    isUsingScatteredInterpolant = true ;
+else
+    isUsingScatteredInterpolant = false ;
+end
+
 
 switch ndims(X_Ep)
-    case 2  
-        % interpolating down to a single-slice
+    case 2  % interpolating down to a single-slice
         gridSizeEp = [ size(X_Ep) 1 ] ;
-    case 3
-        % interpolating to a 3d volume
+    case 3 % interpolating to a 3d volume
         gridSizeEp = size(X_Ep) ;
-    otherwise
-        % sanity check 
+    otherwise % sanity check 
         error('Expected 2d or 3d target interpolation grid')
 end
 
 % sanity check    
 assert( [all(gridSizeEp>=1)] & [nnz(gridSizeEp==1)<=1], ...
     'Unexpected result for size of grid coordinates:' );
-
-gridSizeIp = size( X_Ip ) ;
 
 if myisfieldfilled( Img.Hdr, 'MaskingImage' ) 
     maskIp = logical( sum( sum( Img.Hdr.MaskingImage, 5 ), 4 ) ) ;
@@ -1279,7 +1270,8 @@ end
 
 if ~exist('maskEp')
     if ~isUsingScatteredInterpolant 
-        warning('No logical mask provided: For faster results, restrict the target/output voxels to those of interest by providing this mask!') ;
+        warning(['No logical mask provided: For faster results, ' ...
+            'restrict the target/output voxels to those of interest by providing this mask!']) ;
     end
     maskEp = true( gridSizeEp ) ;
 end

--- a/Img/MaRdI.m
+++ b/Img/MaRdI.m
@@ -1250,27 +1250,31 @@ else
     error('Dimensions of input Img.img must be >= 2, and <= 5') ;
 end
 
-if ndims( X_Ep ) == 2 % interpolating down to 2d single-slice
-    gridSizeEp = [ size(X_Ep) 1 ] ;
-elseif ndims( X_Ep ) == 3
-    gridSizeEp = size(X_Ep) ;
-else
-    error('Expected 2d or 3d target interpolation grid')
+% -----------------
+%% Define variables
+
+switch ndims(X_Ep)
+    case 2  
+        % interpolating down to a single-slice
+        gridSizeEp = [ size(X_Ep) 1 ] ;
+    case 3
+        % interpolating to a 3d volume
+        gridSizeEp = size(X_Ep) ;
+    otherwise
+        % sanity check 
+        error('Expected 2d or 3d target interpolation grid')
 end
 
-%% -----
-% Define variables
+% sanity check    
+assert( [all(gridSizeEp>=1)] & [nnz(gridSizeEp==1)<=1], ...
+    'Unexpected result for size of grid coordinates:' );
+
 gridSizeIp = size( X_Ip ) ;
 
 if myisfieldfilled( Img.Hdr, 'MaskingImage' ) 
     maskIp = logical( sum( sum( Img.Hdr.MaskingImage, 5 ), 4 ) ) ;
 else
     maskIp = true( gridSizeIp ) ;
-end
-
-gridSizeEp = size( X_Ep ) ;
-if ndims(gridSizeEp) == 2
-    gridSizeEp = [gridSizeEp 1] ;
 end
 
 if ~exist('maskEp')

--- a/Img/MaRdI.m
+++ b/Img/MaRdI.m
@@ -1274,6 +1274,15 @@ if ~exist('maskEp')
             'restrict the target/output voxels to those of interest by providing this mask!']) ;
     end
     maskEp = true( gridSizeEp ) ;
+else
+    if gridSizeEp(3) > 1
+        gridSizeMaskEp = size(maskEp)
+    else
+        gridSizeMaskEp = [size(maskEp) 1]
+    end
+    assert( isequal(gridSizeMaskEp, gridSizeEp), ...
+        [ 'Dimensions of the arrays of extrapolation coordinate ' ...
+          'and the assigned extrapolation ROI mask must be identical' ] );
 end
 
 iEp = find( maskEp(:) ) ; % indices of target voxels


### PR DESCRIPTION
PR fixes #161 — bug in MaRdI.m ([constructor](https://github.com/shimming-toolbox/shimming-toolbox/blob/9081cdac6701d7df74c5db109c205655be10d54e/Img/MaRdI.m#L121)) when the number of image volumes acquired for a given series (a.k.a. number of repetitions, or measurements) as stated in the dicom header differs from the number of image files discovered (i.e. provided by the user). 

- `MaRdI()` now issues a warning when such a discrepancy occurs; nevertheless proceeding with object construction.

Also fixed are several erroneous variable assignments/reassignments in [`MaRdI.resliceimg()` ](https://github.com/shimming-toolbox/shimming-toolbox/blob/9081cdac6701d7df74c5db109c205655be10d54e/Img/MaRdI.m#L1150) re: array dimensions.